### PR TITLE
[#1196]fix: slowdown when rotating toward the goal

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_limits.h
+++ b/base_local_planner/include/base_local_planner/local_planner_limits.h
@@ -61,6 +61,8 @@ public:
   double yaw_goal_tolerance;
   double trans_stopped_vel;
   double theta_stopped_vel;
+  double yaw_slowdown_tolerance;
+  double slowdown_vel_theta;
   bool   restore_defaults;
 
   LocalPlannerLimits() {}
@@ -80,6 +82,8 @@ public:
       double nacc_lim_trans,
       double nxy_goal_tolerance,
       double nyaw_goal_tolerance,
+      double nyaw_slowdown_tolerance,
+      double nslowdown_vel_theta,
       bool   nprune_plan = true,
       double ntrans_stopped_vel = 0.1,
       double ntheta_stopped_vel = 0.1):
@@ -98,6 +102,8 @@ public:
         prune_plan(nprune_plan),
         xy_goal_tolerance(nxy_goal_tolerance),
         yaw_goal_tolerance(nyaw_goal_tolerance),
+        yaw_slowdown_tolerance(nyaw_slowdown_tolerance),
+        slowdown_vel_theta(nslowdown_vel_theta),
         trans_stopped_vel(ntrans_stopped_vel),
         theta_stopped_vel(ntheta_stopped_vel) {}
 

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -254,6 +254,10 @@ bool LatchedStopRotateController::computeVelocityCommandsStopRotate(geometry_msg
     else {
       //set this so that we know its OK to be moving
       rotating_to_goal_ = true;
+      if (fabs(angle) <= limits.yaw_slowdown_tolerance)
+      {
+        limits.max_vel_theta = limits.slowdown_vel_theta;
+      }
       if ( ! rotateToGoal(
           global_pose,
           robot_vel,

--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -36,4 +36,7 @@ gen.add("use_dwa", bool_t, 0, "Use dynamic window approach to constrain sampling
 
 gen.add("restore_defaults", bool_t, 0, "Restore to the original configuration.", False)
 
+gen.add("yaw_slowdown_tolerance", double_t, 0, "Within what maximum angle difference we consider the robot to face slowdown direction", 0.60)
+gen.add("slowdown_vel_theta", double_t, 0, "The absolute value of the slowdown rotational velocity for the robot in rad/s",  0.5, 0, 20.0)
+
 exit(gen.generate("dwa_local_planner", "dwa_local_planner", "DWAPlanner"))

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -49,6 +49,7 @@
 
 #include <nav_msgs/Odometry.h>
 #include <std_msgs/String.h>
+#include <std_srvs/Empty.h>
 
 #include <costmap_2d/costmap_2d_ros.h>
 #include <nav_core/base_local_planner.h>
@@ -117,6 +118,7 @@ namespace dwa_local_planner {
 
       void actuator_position_callback(const lexxauto_msgs::ActuatorStatus::ConstPtr& msg);
 
+      void call_nomotion_update_callback(const ros::TimerEvent& event);
       bool isInitialized() {
         return initialized_;
       }
@@ -136,6 +138,8 @@ namespace dwa_local_planner {
       // for visualisation, publishers of global and local plan
       ros::Publisher g_plan_pub_, l_plan_pub_;
       ros::Subscriber actuator_position_sub_;
+      ros::ServiceClient nomotion_update_client_;
+      ros::Timer nomotion_update_timer_;
 
       base_local_planner::LocalPlannerUtil planner_util_;
 
@@ -171,6 +175,7 @@ namespace dwa_local_planner {
       bool rotate_to_goal_;
       bool use_rotate_first_actuator_connect_;
       bool use_rotate_first_actuator_disconnect_;
+      bool is_force_update_;
   };
 };
 #endif


### PR DESCRIPTION
ゴール到着時の回転の際に、目標の向きの近くになった時点で減速して位置合わせをしてから最終的に止まるように修正。
向き合わせの回転中に、amclのnomotion updateを常に実行し続けるように修正。
ゴールに到着した時点でamclのnomotion updateを実行するように修正。