### PR TITLE
1321 recovery behavior

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -218,6 +218,7 @@ namespace move_base {
       ros::Subscriber goal_sub_, carrying_status_sub_;
       ros::ServiceServer make_plan_srv_, clear_costmaps_srv_;
       bool shutdown_costmaps_, clearing_rotation_allowed_, recovery_behavior_enabled_, backward_recovery_allowed_, abort_after_recovery_allowed_;
+      bool conservative_clearing_map_allowed_, aggressive_clearing_map_allowed_;
       double oscillation_timeout_, oscillation_distance_;
       double rotate_small_angle_;
       lexxauto_msgs::ActuatorStatus actuator_position;

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -109,6 +109,7 @@ namespace move_base {
       double pre_body_yaw_ = 0;
       bool detectMotionStuck();
       bool use_safety_direction_recovery_in_towing_;
+      bool use_rotate_recovery_in_towing_;
 
       geometry_msgs::Twist cmd_vel_;
 

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1204,11 +1204,19 @@ namespace move_base {
 
       //Newly added: load a recovery behavior to move safety places
       boost::shared_ptr<nav_core::RecoveryBehavior> safety_direction(recovery_loader_.createInstance("safety_direction_recovery/SafetyDirectionRecovery"));
-      for (int i=0; i<5; i++) {
-        safety_direction->initialize("safety_direction_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-        recovery_behaviors_.push_back(safety_direction);
-        if (use_safety_direction_recovery_in_towing_) {
-          recovery_behaviors_carrying_.push_back(safety_direction);
+      boost::shared_ptr<nav_core::RecoveryBehavior> rotate(recovery_loader_.createInstance("rotate_recovery/RotateRecovery"));
+      for (int i=0; i<3; i++) {
+        for (int j=0; j<2; j++) {
+          safety_direction->initialize("safety_direction_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+          recovery_behaviors_.push_back(safety_direction);
+          if (use_safety_direction_recovery_in_towing_) {
+            recovery_behaviors_carrying_.push_back(safety_direction);
+          }
+        }
+        if(clearing_rotation_allowed_){
+          rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+          recovery_behaviors_.push_back(rotate);
+          recovery_behaviors_carrying_.push_back(rotate);
         }
       }
 
@@ -1228,7 +1236,6 @@ namespace move_base {
       }
 
       //next, we'll load a recovery behavior to rotate in place
-      boost::shared_ptr<nav_core::RecoveryBehavior> rotate(recovery_loader_.createInstance("rotate_recovery/RotateRecovery"));
       if(clearing_rotation_allowed_){
         rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
         recovery_behaviors_.push_back(rotate);

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -81,6 +81,7 @@ namespace move_base {
     private_nh.param("oscillation_distance", oscillation_distance_, 0.5);
 
     private_nh.param("use_safety_direction_recovery_in_towing", use_safety_direction_recovery_in_towing_, true);
+    private_nh.param("use_rotate_recovery_in_towing", use_rotate_recovery_in_towing_, true);
 
     //set up plan triple buffer
     planner_plan_ = new std::vector<geometry_msgs::PoseStamped>();
@@ -1202,43 +1203,47 @@ namespace move_base {
       n.setParam("conservative_reset/reset_distance", 0.0); //conservative_reset_dist_);
       n.setParam("aggressive_reset/reset_distance", 0.0); //circumscribed_radius_ * 4);
 
-      //Newly added: load a recovery behavior to move safety places
       boost::shared_ptr<nav_core::RecoveryBehavior> safety_direction(recovery_loader_.createInstance("safety_direction_recovery/SafetyDirectionRecovery"));
       boost::shared_ptr<nav_core::RecoveryBehavior> rotate(recovery_loader_.createInstance("rotate_recovery/RotateRecovery"));
-      for (int i=0; i<3; i++) {
-        for (int j=0; j<2; j++) {
+      boost::shared_ptr<nav_core::RecoveryBehavior> go_back(recovery_loader_.createInstance("go_back_recovery/GoBackRecovery"));
+      boost::shared_ptr<nav_core::RecoveryBehavior> rotate_small(recovery_loader_.createInstance("rotate_small_recovery/RotateSmallRecovery"));
+
+      int outer_loop_recovery_count = 3;
+      int inner_loop_recovery_count = 2;
+      for (int i=0; i<outer_loop_recovery_count; i++)
+      {
+        for (int j=0; j<inner_loop_recovery_count; j++)
+        {
           safety_direction->initialize("safety_direction_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
           recovery_behaviors_.push_back(safety_direction);
-          if (use_safety_direction_recovery_in_towing_) {
+          if (use_safety_direction_recovery_in_towing_)
+          {
             recovery_behaviors_carrying_.push_back(safety_direction);
           }
+          else
+          {
+            if (backward_recovery_allowed_)
+            {
+              go_back->initialize("go_back_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+              recovery_behaviors_carrying_.push_back(go_back);
+            }
+
+            if (clearing_rotation_allowed_ && rotate_small_angle_ != 0.0)
+            {
+              rotate_small->initialize("rotate_small_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+              recovery_behaviors_carrying_.push_back(rotate_small);
+            }
+          }
         }
-        if(clearing_rotation_allowed_){
+        if (clearing_rotation_allowed_)
+        {
           rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
           recovery_behaviors_.push_back(rotate);
-          recovery_behaviors_carrying_.push_back(rotate);
+          if (use_rotate_recovery_in_towing_)
+          {
+            recovery_behaviors_carrying_.push_back(rotate);
+          }
         }
-      }
-
-      //Newly added: load a recovery behavior to move backwards
-      boost::shared_ptr<nav_core::RecoveryBehavior> go_back(recovery_loader_.createInstance("go_back_recovery/GoBackRecovery"));
-      if(backward_recovery_allowed_){
-        go_back->initialize("go_back_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-//        recovery_behaviors_.push_back(go_back);
-        recovery_behaviors_carrying_.push_back(go_back);
-      }
-
-      //Newly added: load a recovery behavior to rotate small angle
-      boost::shared_ptr<nav_core::RecoveryBehavior> rotate_small(recovery_loader_.createInstance("rotate_small_recovery/RotateSmallRecovery"));
-      if(clearing_rotation_allowed_ && rotate_small_angle_ != 0.0){
-        rotate_small->initialize("rotate_small_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-        recovery_behaviors_carrying_.push_back(rotate_small);
-      }
-
-      //next, we'll load a recovery behavior to rotate in place
-      if(clearing_rotation_allowed_){
-        rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-        recovery_behaviors_.push_back(rotate);
       }
 
 /*

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -1195,9 +1195,16 @@ namespace move_base {
       n.setParam("aggressive_reset/reset_distance", 0.0); //circumscribed_radius_ * 4);
 
       boost::shared_ptr<nav_core::RecoveryBehavior> safety_direction(recovery_loader_.createInstance("safety_direction_recovery/SafetyDirectionRecovery"));
+      safety_direction->initialize("safety_direction_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+
       boost::shared_ptr<nav_core::RecoveryBehavior> rotate(recovery_loader_.createInstance("rotate_recovery/RotateRecovery"));
+      rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+
       boost::shared_ptr<nav_core::RecoveryBehavior> go_back(recovery_loader_.createInstance("go_back_recovery/GoBackRecovery"));
+      go_back->initialize("go_back_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
+
       boost::shared_ptr<nav_core::RecoveryBehavior> rotate_small(recovery_loader_.createInstance("rotate_small_recovery/RotateSmallRecovery"));
+      rotate_small->initialize("rotate_small_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
 
       int outer_loop_recovery_count = 3;
       int inner_loop_recovery_count = 2;
@@ -1205,7 +1212,6 @@ namespace move_base {
       {
         for (int j=0; j<inner_loop_recovery_count; j++)
         {
-          safety_direction->initialize("safety_direction_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
           recovery_behaviors_.push_back(safety_direction);
           if (use_safety_direction_recovery_in_towing_)
           {
@@ -1215,20 +1221,17 @@ namespace move_base {
           {
             if (backward_recovery_allowed_)
             {
-              go_back->initialize("go_back_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
               recovery_behaviors_carrying_.push_back(go_back);
             }
 
             if (clearing_rotation_allowed_ && rotate_small_angle_ != 0.0)
             {
-              rotate_small->initialize("rotate_small_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
               recovery_behaviors_carrying_.push_back(rotate_small);
             }
           }
         }
         if (clearing_rotation_allowed_)
         {
-          rotate->initialize("rotate_recovery", &tf_, planner_costmap_ros_, controller_costmap_ros_);
           recovery_behaviors_.push_back(rotate);
           if (use_rotate_recovery_in_towing_)
           {

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -483,15 +483,6 @@ namespace move_base {
 
   bool MoveBase::makePlan(const geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& plan){
     boost::unique_lock<costmap_2d::Costmap2D::mutex_t> lock(*(planner_costmap_ros_->getCostmap()->getMutex()));
-/*
-    for (int i=0; i<controller_costmap_ros_->getCostmap()->getSizeInCellsX(); i++)
-    {
-      for (int j=0; j<controller_costmap_ros_->getCostmap()->getSizeInCellsY(); j++)
-      {
-        ROS_INFO("costmap val: (i, j, val) = (, %d, %d, %d, )", i, j, controller_costmap_ros_->getCostmap()->getCost(i,j));
-      }
-    }
-*/
 
     //make sure to set the plan to be empty initially
     plan.clear();
@@ -1246,22 +1237,6 @@ namespace move_base {
         }
       }
 
-/*
-      // we'll load a recovery behavior that will do an aggressive reset of the costmap
-      boost::shared_ptr<nav_core::RecoveryBehavior> ags_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
-      ags_clear->initialize("aggressive_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-      recovery_behaviors_.push_back(ags_clear);
-      recovery_behaviors_carrying_.push_back(ags_clear);
-
-      // we'll load a recovery behavior to clear the costmap
-      boost::shared_ptr<nav_core::RecoveryBehavior> cons_clear(recovery_loader_.createInstance("clear_costmap_recovery/ClearCostmapRecovery"));
-      cons_clear->initialize("conservative_reset", &tf_, planner_costmap_ros_, controller_costmap_ros_);
-      recovery_behaviors_.push_back(cons_clear);
-      recovery_behaviors_carrying_.push_back(cons_clear);
-
-      // we'll rotate in-place one more time
-      if(clearing_rotation_allowed_) recovery_behaviors_.push_back(rotate);
-*/
     }
     catch(pluginlib::PluginlibException& ex){
       ROS_FATAL("Failed to load a plugin. This should not happen on default recovery behaviors. Error: %s", ex.what());


### PR DESCRIPTION
リカバリー時の挙動を整理しました。元々7回safety_direction_recoveryを実行（実行中にpathを見つけたらリカバリー終了）としていたのですが、以下のような問題がありました。
- 7回連続でsafety_direction_recoveryを実行するのは冗長
- 自己位置ずれの際は、safety_direction_recoveryよりも回転してリカバリした方が効果的
- safety_direction_recoveryのあとにgo_back_recoveryとrotate_small_recoveryをしていたが、safety_direction_recoveryの方が効果的なので冗長。

そこで、以下のシーケンスを3回繰り返すように整理しました。
1. 2回safety_direction_recovery（もしくはgo_back_recoveryとrotate_small_recovery）を実行
2. rotate_recoveryの実行