### PR TITLE
1406 catch connectivity exception unittest

### DIFF
--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -43,7 +43,7 @@ class TestBasicLocalization(unittest.TestCase):
             pass
         except (tf2.ConnectivityException) as e:
             self.connectivityExceptions = self.connectivityExceptions + 1
-            if (self.connectivityExceptions >  self.maxConnectivityExceptions):
+            if (self.connectivityExceptions >= self.maxConnectivityExceptions):
                 raise tf2.ConnectivityException(e)
             time.sleep(0.5)
             pass

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -23,6 +23,8 @@ class TestBasicLocalization(unittest.TestCase):
         self.target_y = None
         self.target_a = None
         self.tfBuffer = None
+        self.maxConnectivityExceptions = 5
+        self.connectivityExceptions = 0
 
     def print_pose_diff(self):
         a_curr = self.compute_angle()
@@ -39,6 +41,13 @@ class TestBasicLocalization(unittest.TestCase):
             self.print_pose_diff()
         except (tf2.LookupException, tf2.ExtrapolationException):
             pass
+        except (tf2.ConnectivityException) as e:
+            self.connectivityExceptions = self.connectivityExceptions + 1
+            if (self.maxConnectivityExceptions >  self.maxConnectivityExceptions):
+                raise tf2.ConnectivityException(e)
+            time.sleep(0.5)
+            pass
+
 
     @staticmethod
     def wrap_angle(angle):

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -43,7 +43,7 @@ class TestBasicLocalization(unittest.TestCase):
             pass
         except (tf2.ConnectivityException) as e:
             self.connectivityExceptions = self.connectivityExceptions + 1
-            if (self.maxConnectivityExceptions >  self.maxConnectivityExceptions):
+            if (self.connectivityExceptions >  self.maxConnectivityExceptions):
                 raise tf2.ConnectivityException(e)
             time.sleep(0.5)
             pass

--- a/amcl/test/basic_localization_stage.xml
+++ b/amcl/test/basic_localization_stage.xml
@@ -47,5 +47,5 @@ setting pose: 30.329 34.644 3.142
       <param name="initial_pose_a" value="-1.003"/>
     </node>
     <test time-limit="180" test-name="basic_localization_stage" pkg="amcl"
-          type="basic_localization.py" args="0 30.329 34.644 3.142 0.75 0.75 90.0"/>
+          type="basic_localization.py" args="0 30.329 34.644 3.142 0.75 0.75 120.0"/>
 </launch>

--- a/amcl/test/basic_localization_stage.xml
+++ b/amcl/test/basic_localization_stage.xml
@@ -47,5 +47,5 @@ setting pose: 30.329 34.644 3.142
       <param name="initial_pose_a" value="-1.003"/>
     </node>
     <test time-limit="180" test-name="basic_localization_stage" pkg="amcl"
-          type="basic_localization.py" args="0 30.329 34.644 3.142 0.75 0.75 120.0"/>
+          type="basic_localization.py" args="0 30.329 34.644 3.142 0.75 0.75 90.0"/>
 </launch>


### PR DESCRIPTION
Since LexxAuto job has been failing due to connectivity issues [1406]( https://github.com/LexxPluss/LexxAuto/issues/1406 ), I implemented the following changes.
These are not a part of the original ros-planning/navigation repository but if our workflow job is gonna randomly fail because of this then I think it's better to implement some exception handler.

What do you think?