### PR TITLE
1450, 1470 goal reached

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -160,7 +160,8 @@ namespace dwa_local_planner {
       bool setup_;
       geometry_msgs::PoseStamped current_pose_;
 
-      base_local_planner::LatchedStopRotateController latchedStopRotateController_;
+      base_local_planner::LatchedStopRotateController goalLatchedStopRotateController_;
+      base_local_planner::LatchedStopRotateController startLatchedStopRotateController_;
 
       double lowPassFilter(double kpre, double& pre_val, double cur_val);
       double kpre_default_ = 0.65;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -174,8 +174,9 @@ namespace dwa_local_planner {
     if (this->latch_unlock_distance_ < d)
     {
       //when we get a new plan, we also want to clear any latch we may have on goal tolerances
-      latchedStopRotateController_.resetLatching();
+      startLatchedStopRotateController_.resetLatching();
     }
+    goalLatchedStopRotateController_.resetLatching();
     if ((this->is_actuator_connect_ && this->use_rotate_first_actuator_connect_) ||
         (!this->is_actuator_connect_ && this->use_rotate_first_actuator_disconnect_))
     {
@@ -202,7 +203,7 @@ namespace dwa_local_planner {
       return false;
     }
 
-    if(latchedStopRotateController_.isGoalReached(&planner_util_, odom_helper_, current_pose_)) {
+    if(goalLatchedStopRotateController_.isGoalReached(&planner_util_, odom_helper_, current_pose_)) {
       ROS_INFO("Goal reached");
       std_srvs::Empty empty_srvs;
       this->nomotion_update_client_.call(empty_srvs);
@@ -376,7 +377,7 @@ namespace dwa_local_planner {
     vel_cmd_mode_marker_msg_.scale.z = 0.3;
     vel_cmd_mode_marker_msg_.color.a = 1.0;
 
-    if (latchedStopRotateController_.isPositionReached(&planner_util_, current_pose_))
+    if (goalLatchedStopRotateController_.isPositionReached(&planner_util_, current_pose_))
     {
       vel_cmd_mode_msg_.data = 1;
       vel_cmd_mode_marker_msg_.color.r = 1.0;
@@ -392,7 +393,7 @@ namespace dwa_local_planner {
       publishGlobalPlan(transformed_plan);
       publishLocalPlan(local_plan);
       base_local_planner::LocalPlannerLimits limits = planner_util_.getCurrentLimits();
-      return latchedStopRotateController_.computeVelocityCommandsStopRotate(
+      return goalLatchedStopRotateController_.computeVelocityCommandsStopRotate(
           cmd_vel,
           limits.getAccLimits(),
           dp_->getSimPeriod(),
@@ -452,7 +453,7 @@ namespace dwa_local_planner {
       double turn_turget_th = std::atan2(turn_turget_y - current_y, turn_turget_x - current_x);
       base_local_planner::LocalPlannerLimits limits = planner_util_.getCurrentLimits();
 
-      bool was_rotate = latchedStopRotateController_.rotateToGoal(
+      bool was_rotate = startLatchedStopRotateController_.rotateToGoal(
         current_pose_,
         robot_vel,
         turn_turget_th,
@@ -481,12 +482,12 @@ namespace dwa_local_planner {
       bool isOk = dwaComputeVelocityCommands(current_pose_, cmd_vel);
       if (isOk) {
         publishGlobalPlan(transformed_plan);
-        this->latchedStopRotateController_.resetLatching();
       } else {
         ROS_WARN_NAMED("dwa_local_planner", "DWA planner failed to produce path.");
         std::vector<geometry_msgs::PoseStamped> empty_plan;
         publishGlobalPlan(empty_plan);
       }
+      this->startLatchedStopRotateController_.resetLatching();
       return isOk;
     }
   }


### PR DESCRIPTION
#1450 と #1470 の対応になります。
対応内容として連動しているので、まとめての対応になります。
スタート時の回転を司る LatchedStopRotateController オブジェクトと、ゴール時の回転を司る LatchedStopRotateController オブジェクトを分離ました。

また、その対応が入った上でも、ゴールが遠いのにゴールした扱いになってしまう事象が発生していたので、
対応として、ゴールかどうか判断する際に、位置が遠かったら再挑戦するように修正しています。

前者の対応については、X-Frontierで全台に適用されています。
後者の対応については、7号機にてX-Frontierで確認しており、今のところ問題は起きていません。