### PR TITLE
[LexxPluss/LexxAuto#1605] fix : goal skip.

### DIFF
--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -222,8 +222,6 @@ namespace dwa_local_planner {
       }
 
       ROS_INFO("Goal reached");
-      std_srvs::Empty empty_srvs;
-      this->nomotion_update_client_.call(empty_srvs);
       return true;
     } else {
       return false;


### PR DESCRIPTION
LexxPluss/LexxAuto#1605 対応。

ゴールに辿り着いた判定をしたタイミングと、新しい経路を受け付けたタイミングによって、前のゴールの到着判定結果が、新しいゴールの判定に使われてしまい、ゴールしていないのにゴールした扱いになってしまっている可能性があった。

その為、ゴール判定を行った後に、ブロッキング処理を行っている箇所であり、コードを入れた当時よりも自己位置の精度が改善しているため、現在では不要と考えている箇所を除去する。

Xフロンティアにて、Git管理外で検証済。