### PR TITLE
[#1878] deactivate low pass filter for dwa planner.

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -170,7 +170,7 @@ namespace dwa_local_planner {
       base_local_planner::LatchedStopRotateController startLatchedStopRotateController_;
 
       double lowPassFilter(double kpre, double& pre_val, double cur_val);
-      double kpre_default_ = 0.65;
+      double kpre_default_ = 0.0;
       double kpre_ = kpre_default_;
 
       bool initialized_;

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -152,7 +152,7 @@ namespace dwa_local_planner {
       
       private_nh.param("use_rotate_first_actuator_connect", this->use_rotate_first_actuator_connect_, false);
       private_nh.param("use_rotate_first_actuator_disconnect", this->use_rotate_first_actuator_disconnect_, true);
-      private_nh.param("kpre", this->kpre_, 0.65);
+      private_nh.param("kpre", this->kpre_, 0.0);
 
       private_nh.param("latch_unlock_distance", this->latch_unlock_distance_, 1.0);
       private_nh.param("cargo_timeout_sec", this->cargo_timeout_sec_, 1.0);


### PR DESCRIPTION
Set low pass filter gain zero as default.

related to https://github.com/LexxPluss/LexxAuto/issues/1878 