### PR TITLE
[LexxPluss/LexxAuto#1938] fix error in calculation of global angle of cargo

### DIFF
--- a/base_local_planner/src/curvature_cost_function.cpp
+++ b/base_local_planner/src/curvature_cost_function.cpp
@@ -39,7 +39,7 @@ double CurvatureCostFunction::scoreTrajectory(Trajectory &traj) {
   {
     norm_cargo_angle += 2 * M_PI;
   }
-  norm_cargo_angle = std::fmod(norm_cargo_angle + M_PI, 2 * M_PI) - M_PI;
+  norm_cargo_angle = std::fmod(norm_cargo_angle, 2 * M_PI) - M_PI;
 
   if (traj.thetav_ == 0.0)
   {

--- a/base_local_planner/src/latched_stop_rotate_controller.cpp
+++ b/base_local_planner/src/latched_stop_rotate_controller.cpp
@@ -191,7 +191,7 @@ bool LatchedStopRotateController::rotateToGoal(
     {
       cargo_global += 2 * M_PI;
     }
-    cargo_global = std::fmod(cargo_global + M_PI, 2 * M_PI) - M_PI;
+    cargo_global = std::fmod(cargo_global, 2 * M_PI) - M_PI;
 
     double ang_diff_yc = angles::shortest_angular_distance(yaw, cargo_global);
     double ang_diff_cg = angles::shortest_angular_distance(cargo_global, goal_th);


### PR DESCRIPTION
LexxPluss/LexxAuto#1938 対応
TailJigの原点がロボット後方が0なので、ロボットの原点に合わせようと180度反転させていたが、
検証したところ不要だった為修正。