### PR TITLE
[LexxPluss/LexxAuto#1776] increase time-limit

### DIFF
--- a/amcl/test/texas_greenroom_loop.xml
+++ b/amcl/test/texas_greenroom_loop.xml
@@ -36,6 +36,6 @@
       <param name="initial_pose_y" value="24.234"/>
       <param name="initial_pose_a" value="-1.517"/>
     </node>
-    <test time-limit="540" test-name="texas_greenroom_loop" pkg="amcl"
+    <test time-limit="1080" test-name="texas_greenroom_loop" pkg="amcl"
           type="basic_localization.py" args="0 13.87 24.07 4.65 0.75 0.75 89.0"/>
 </launch>


### PR DESCRIPTION
LexxPluss/LexxAuto#1776 関連
Updated time limits for tests that may fail with timeouts at runtime in github actions.
github actionsで実行時にタイムアウトで失敗することがあるテストのタイムリミットを更新。