### PR TITLE
fix test

### DIFF
--- a/amcl/test/texas_greenroom_loop.xml
+++ b/amcl/test/texas_greenroom_loop.xml
@@ -3,7 +3,7 @@
     <param name="/use_sim_time" value="true"/>
     <node name="map_server" pkg="map_server" type="map_server" args="$(find amcl)/test/willow-full-0.05.pgm 0.05"/>
     <node name="rosbag" pkg="rosbag" type="play"
-          args="-s 15.0 -d 1 -r 2 --clock --hz 10 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
+          args="-s 15.0 -d 1 -r 1 --clock --hz 20 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
     <node pkg="amcl" type="amcl" name="amcl" respawn="false" output="screen">
       <remap from="scan" to="base_scan" />
       <param name="transform_tolerance" value="0.2"/>

--- a/amcl/test/texas_greenroom_loop.xml
+++ b/amcl/test/texas_greenroom_loop.xml
@@ -3,7 +3,7 @@
     <param name="/use_sim_time" value="true"/>
     <node name="map_server" pkg="map_server" type="map_server" args="$(find amcl)/test/willow-full-0.05.pgm 0.05"/>
     <node name="rosbag" pkg="rosbag" type="play"
-          args="-s 15.0 -d 1 -r 1 --clock --hz 20 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
+          args="-s 15.0 -d 1 -r 0.5 --clock --hz 10 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
     <node pkg="amcl" type="amcl" name="amcl" respawn="false" output="screen">
       <remap from="scan" to="base_scan" />
       <param name="transform_tolerance" value="0.2"/>
@@ -36,6 +36,6 @@
       <param name="initial_pose_y" value="24.234"/>
       <param name="initial_pose_a" value="-1.517"/>
     </node>
-    <test time-limit="120" test-name="texas_greenroom_loop" pkg="amcl"
+    <test time-limit="300" test-name="texas_greenroom_loop" pkg="amcl"
 	    type="basic_localization.py" args="0 13.87 24.07 4.65 0.75 0.75 89.0"/>
 </launch>

--- a/amcl/test/texas_greenroom_loop.xml
+++ b/amcl/test/texas_greenroom_loop.xml
@@ -3,7 +3,7 @@
     <param name="/use_sim_time" value="true"/>
     <node name="map_server" pkg="map_server" type="map_server" args="$(find amcl)/test/willow-full-0.05.pgm 0.05"/>
     <node name="rosbag" pkg="rosbag" type="play"
-          args="-s 15.0 -d 1 -r 1 --clock --hz 10 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
+          args="-s 15.0 -d 1 -r 2 --clock --hz 10 $(find amcl)/test/texas_greenroom_loop_indexed.bag"/>
     <node pkg="amcl" type="amcl" name="amcl" respawn="false" output="screen">
       <remap from="scan" to="base_scan" />
       <param name="transform_tolerance" value="0.2"/>
@@ -36,6 +36,6 @@
       <param name="initial_pose_y" value="24.234"/>
       <param name="initial_pose_a" value="-1.517"/>
     </node>
-    <test time-limit="1080" test-name="texas_greenroom_loop" pkg="amcl"
-          type="basic_localization.py" args="0 13.87 24.07 4.65 0.75 0.75 89.0"/>
+    <test time-limit="120" test-name="texas_greenroom_loop" pkg="amcl"
+	    type="basic_localization.py" args="0 13.87 24.07 4.65 0.75 0.75 89.0"/>
 </launch>

--- a/amcl/test/texas_willow_hallway_loop.xml
+++ b/amcl/test/texas_willow_hallway_loop.xml
@@ -3,7 +3,7 @@
     <param name="/use_sim_time" value="true"/>
     <node name="map_server" pkg="map_server" type="map_server" args="$(find amcl)/test/willow-full-0.05.pgm 0.05"/>
     <node name="rosbag" pkg="rosbag" type="play"
-          args="-s 15.0 -d 1 -r 1 --clock --hz 10 $(find amcl)/test/texas_willow_hallway_loop_indexed.bag"/>
+          args="-s 15.0 -d 1 -r 0.5 --clock --hz 10 $(find amcl)/test/texas_willow_hallway_loop_indexed.bag"/>
     <node pkg="amcl" type="amcl" name="amcl" respawn="false" output="screen">
       <remap from="scan" to="base_scan" />
       <param name="transform_tolerance" value="0.2"/>
@@ -36,6 +36,6 @@
       <param name="initial_pose_y" value="31.557"/>
       <param name="initial_pose_a" value="0.0"/>
     </node>
-    <test time-limit="350" test-name="texas_willow_hallway_loop" pkg="amcl"
+    <test time-limit="550" test-name="texas_willow_hallway_loop" pkg="amcl"
           type="basic_localization.py" args="0 32.36 31.44 6.18 0.75 0.75 250.0"/>
 </launch>


### PR DESCRIPTION
LexxPluss/LexxAuto#1832 でsubmoduleで参照するリポジトリを lexxauto-main ではなく lexxauto-1832-fix-test としていました。他プロジェクトの開発を優先したのと、効果がどれだけあるかが怪しい部分があったためです。
今回 LexxPluss/LexxAuto#2584 でlexxauto-mainへ反映したいと考えます。最近amcl要因でのテスト失敗はほぼほぼ無くなっているという認識です。

どうやったらテストが成功するようになったかについてです。
rosbagの再生周期を遅くしました。
Github actionsのテストランナーのスペックが低いのか、処理が追いつかずデータの取りこぼしが発生し、テストが完了しないことがあるようです。

I had been using lexxauto-1832-fix-test instead of lexxauto-main as the repository referenced by submodule in LexxPluss/LexxAuto#1832. This is because we prioritized the development of other projects, and also because we were not sure how effective it would be.
This time I would like to reflect it to lexxauto-main in LexxPluss/LexxAuto#2584. We are aware that test failures with the amcl factor have been almost non-existent recently.

I would like to know how to make the test succeed.
We slowed down the playback cycle of rosbag.
It seems that the specs of the test runner of Github actions are low, or the processing does not catch up with the specs of the test runner, and the test sometimes does not complete due to overflow of data.
