### PR TITLE
[AMRSW-241] prototype: cmd_vel value for variable inflation.

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -171,6 +171,9 @@ if(CATKIN_ENABLE_TESTING)
   add_dependencies(tests inflation_tests)
   target_link_libraries(inflation_tests costmap_2d layers ${GTEST_LIBRARIES})
 
+  add_rostest_gtest(inflation_tests_unit test/inflation_tests_unit.launch test/inflation_tests_unit.cpp)
+  target_link_libraries(inflation_tests_unit layers ${catkin_LIBRARIES})
+
   catkin_download_test_data(${PROJECT_NAME}_simple_driving_test_indexed.bag
     http://download.ros.org/data/costmap_2d/simple_driving_test_indexed.bag
     DESTINATION ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}/test

--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -9,7 +9,7 @@ gen.add("cost_scaling_factor", double_t, 0, "A scaling factor to apply to cost v
 gen.add("inflation_radius", double_t, 0, "The radius in meters to which the map inflates obstacle cost values.", 0.55, 0, 50)
 gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False)
 
-gen.add("use_variable_inflation", bool_t, 0, "Whether to change inflation while moving", True)
+gen.add("use_variable_inflation", bool_t, 0, "Whether to change inflation while moving", False)
 gen.add("min_inflation_radius", double_t, 0, "Minimum inflation radius", 0.2, 0.0, 1.0)
 gen.add("max_inflation_radius", double_t, 0, "Maximum inflation radius", 0.6, 0.0, 5.0)
 gen.add("min_inflation_vel", double_t, 0, "Minimum inflation velocity to activate variable inflation", 0.3, 0.0, 1.0)

--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -9,4 +9,10 @@ gen.add("cost_scaling_factor", double_t, 0, "A scaling factor to apply to cost v
 gen.add("inflation_radius", double_t, 0, "The radius in meters to which the map inflates obstacle cost values.", 0.55, 0, 50)
 gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False)
 
+gen.add("use_variable_inflation", bool_t, 0, "Whether to change inflation while moving", True)
+gen.add("min_inflation_radius", double_t, 0, "Minimum inflation radius", 0.2, 0.0, 1.0)
+gen.add("max_inflation_radius", double_t, 0, "Maximum inflation radius", 0.6, 0.0, 5.0)
+gen.add("min_inflation_vel", double_t, 0, "Minimum inflation velocity to activate variable inflation", 0.3, 0.0, 1.0)
+gen.add("max_inflation_vel", double_t, 0, "Maximum inflation velocity to activate variable inflation", 0.7, 0.0, 2.0)
+
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -44,6 +44,7 @@
 #include <costmap_2d/InflationPluginConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <boost/thread.hpp>
+#include <geometry_msgs/Twist.h>
 
 namespace costmap_2d
 {
@@ -85,6 +86,10 @@ public:
     if (seen_)
         delete[] seen_;
   }
+
+  ros::Subscriber vel_sub;
+  geometry_msgs::Twist vel_msg;
+  void vel_callback(const geometry_msgs::Twist::ConstPtr& msg);
 
   virtual void onInitialize();
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -127,14 +127,24 @@ public:
    * @brief Change the values of the inflation radius parameters
    * @param inflation_radius The new inflation radius
    * @param cost_scaling_factor The new weight
+   * @param use_variable_inflation Use variable inflation or not
+   * @param min_inflation_radius The minimum inflation radius
+   * @param max_inflation_radius The maximum inflation radius
+   * @param min_inflation_vel The minimum velocity to activate variable inflation
+   * @param max_inflation_vel The maximum velocity to activate variable inflation
    */
-  void setInflationParameters(double inflation_radius, double cost_scaling_factor);
+  void setInflationParameters(double inflation_radius,
+                              double cost_scaling_factor,
+                              bool use_variable_inflation,
+                              double min_inflation_radius,
+                              double max_inflation_radius,
+                              double min_inflation_vel,
+                              double max_inflation_vel);
 
 protected:
   virtual void onFootprintChanged();
   boost::recursive_mutex* inflation_access_;
   boost::recursive_mutex* velocity_access_;
-  boost::recursive_mutex* config_access_;
 
   double resolution_;
   double inflation_radius_;

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -133,6 +133,8 @@ public:
 protected:
   virtual void onFootprintChanged();
   boost::recursive_mutex* inflation_access_;
+  boost::recursive_mutex* velocity_access_;
+  boost::recursive_mutex* config_access_;
 
   double resolution_;
   double inflation_radius_;

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -139,6 +139,11 @@ protected:
   double inscribed_radius_;
   double weight_;
   bool inflate_unknown_;
+  bool use_variable_inflation_ = true;
+  double min_inflation_radius_ = 0.1;
+  double max_inflation_radius_ = 0.5;
+  double min_inflation_vel_ = 0.2;
+  double max_inflation_vel_ = 0.6;
 
 private:
   /**
@@ -174,6 +179,8 @@ private:
   void computeCaches();
   void deleteKernels();
   void inflate_area(int min_i, int min_j, int max_i, int max_j, unsigned char* master_grid);
+
+  double calculate_variable_inflation_radius();
 
   unsigned int cellDistance(double world_dist)
   {

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -44,7 +44,7 @@
 #include <costmap_2d/InflationPluginConfig.h>
 #include <dynamic_reconfigure/server.h>
 #include <boost/thread.hpp>
-#include <geometry_msgs/Twist.h>
+#include <lexxauto_msgs/DiffDriveEffortControllerDebug.h>
 
 namespace costmap_2d
 {
@@ -87,9 +87,9 @@ public:
         delete[] seen_;
   }
 
-  ros::Subscriber vel_sub;
-  geometry_msgs::Twist vel_msg;
-  void vel_callback(const geometry_msgs::Twist::ConstPtr& msg);
+  ros::Subscriber diff_drive_debug_info_sub;
+  lexxauto_msgs::DiffDriveEffortControllerDebug diff_drive_debug_info_msg;
+  void diff_drive_debug_info_callback(const lexxauto_msgs::DiffDriveEffortControllerDebug::ConstPtr& msg);
 
   virtual void onInitialize();
   virtual void updateBounds(double robot_x, double robot_y, double robot_yaw, double* min_x, double* min_y,

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -139,7 +139,7 @@ protected:
   double inscribed_radius_;
   double weight_;
   bool inflate_unknown_;
-  bool use_variable_inflation_ = true;
+  bool use_variable_inflation_ = false;
   double min_inflation_radius_ = 0.1;
   double max_inflation_radius_ = 0.5;
   double min_inflation_vel_ = 0.2;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -67,18 +67,20 @@ InflationLayer::InflationLayer()
   , last_max_y_(std::numeric_limits<float>::max())
 {
   inflation_access_ = new boost::recursive_mutex();
+  velocity_access_ = new boost::recursive_mutex();
+  config_access_ = new boost::recursive_mutex();
 }
 
 void InflationLayer::diff_drive_debug_info_callback(const lexxauto_msgs::DiffDriveEffortControllerDebug::ConstPtr& msg)
 {
-  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_v(*velocity_access_);
   diff_drive_debug_info_msg = *msg;
 }
 
 void InflationLayer::onInitialize()
 {
   {
-    boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+    boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
     diff_drive_debug_info_sub = g_nh.subscribe<lexxauto_msgs::DiffDriveEffortControllerDebug>
       ("/robot1/diff_drive_effort_controller/debug_info", 1, &InflationLayer::diff_drive_debug_info_callback, this);
@@ -109,15 +111,7 @@ void InflationLayer::onInitialize()
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
   setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
-  std::cerr << "inflation radius: " << config.inflation_radius << std::endl;
-  std::cerr << "cost scaling factor: " << config.cost_scaling_factor << std::endl;
-  std::cerr << "use_variable_inflation: " << config.use_variable_inflation << std::endl;
-  std::cerr << "min_inflation_radius: " << config.min_inflation_radius << std::endl;
-  std::cerr << "max_inflation_radius: " << config.max_inflation_radius << std::endl;
-  std::cerr << "min_inflation_vel: " << config.min_inflation_vel << std::endl;
-  std::cerr << "max_inflation_vel: " << config.max_inflation_vel << std::endl;
-
-  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
   use_variable_inflation_ = config.use_variable_inflation;
   min_inflation_radius_ = config.min_inflation_radius;
   max_inflation_radius_ = config.max_inflation_radius;
@@ -133,7 +127,7 @@ void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, ui
 
 void InflationLayer::matchSize()
 {
-  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
   costmap_2d::Costmap2D* costmap = layered_costmap_->getCostmap();
   resolution_ = costmap->getResolution();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
@@ -195,6 +189,8 @@ void InflationLayer::onFootprintChanged()
 
 double InflationLayer::calculate_variable_inflation_radius()
 {
+  boost::unique_lock < boost::recursive_mutex > lock_v(*velocity_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
   double variable_inflation_radius = min_inflation_radius_;
   const double measured_velocity = diff_drive_debug_info_msg.measured_twist_filtered.linear.x;
 
@@ -221,7 +217,8 @@ double InflationLayer::calculate_variable_inflation_radius()
 
 void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
-  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
+  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
 
   if (use_variable_inflation_)
   {
@@ -425,7 +422,7 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
-    boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+    boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
 
     inflation_radius_ = inflation_radius;
     cell_inflation_radius_ = cellDistance(inflation_radius_);

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -206,9 +206,8 @@ double InflationLayer::calculate_variable_inflation_radius()
   }
   else
   {
-    variable_inflation_radius = (max_inflation_radius_ - min_inflation_radius_) /
-                                (max_inflation_vel_ - min_inflation_vel_) *
-                                std::abs(measured_velocity);
+    double k = (max_inflation_radius_ - min_inflation_radius_) / (max_inflation_vel_ - min_inflation_vel_);
+    variable_inflation_radius = k * (std::abs(measured_velocity) - min_inflation_vel_) + min_inflation_radius_;
     ROS_INFO("calculated inflation radius is %f.", variable_inflation_radius);
   }
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -68,7 +68,6 @@ InflationLayer::InflationLayer()
 {
   inflation_access_ = new boost::recursive_mutex();
   velocity_access_ = new boost::recursive_mutex();
-  config_access_ = new boost::recursive_mutex();
 }
 
 void InflationLayer::diff_drive_debug_info_callback(const lexxauto_msgs::DiffDriveEffortControllerDebug::ConstPtr& msg)
@@ -110,13 +109,9 @@ void InflationLayer::onInitialize()
 
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
-  setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
-  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
-  use_variable_inflation_ = config.use_variable_inflation;
-  min_inflation_radius_ = config.min_inflation_radius;
-  max_inflation_radius_ = config.max_inflation_radius;
-  min_inflation_vel_ = config.min_inflation_vel;
-  max_inflation_vel_ = config.max_inflation_vel;
+  setInflationParameters(config.inflation_radius, config.cost_scaling_factor, config.use_variable_inflation,
+                         config.min_inflation_radius, config.max_inflation_radius,
+                         config.min_inflation_vel, config.max_inflation_vel);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -190,7 +185,6 @@ void InflationLayer::onFootprintChanged()
 double InflationLayer::calculate_variable_inflation_radius()
 {
   boost::unique_lock < boost::recursive_mutex > lock_v(*velocity_access_);
-  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
   double variable_inflation_radius = min_inflation_radius_;
   const double measured_velocity = diff_drive_debug_info_msg.measured_twist_filtered.linear.x;
 
@@ -217,12 +211,13 @@ double InflationLayer::calculate_variable_inflation_radius()
 void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
-  boost::unique_lock < boost::recursive_mutex > lock_c(*config_access_);
 
   if (use_variable_inflation_)
   {
     double variable_inflation_radius = calculate_variable_inflation_radius();
-    setInflationParameters(variable_inflation_radius, weight_);
+    setInflationParameters(variable_inflation_radius, weight_, use_variable_inflation_,
+                           min_inflation_radius_, max_inflation_radius_,
+                           min_inflation_vel_, max_inflation_vel_);
   }
 
   if (!enabled_ || (cell_inflation_radius_ == 0))
@@ -415,9 +410,17 @@ void InflationLayer::deleteKernels()
   }
 }
 
-void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor)
+void InflationLayer::setInflationParameters(double inflation_radius,
+                                            double cost_scaling_factor,
+                                            bool use_variable_inflation,
+                                            double min_inflation_radius,
+                                            double max_inflation_radius,
+                                            double min_inflation_vel,
+                                            double max_inflation_vel)
 {
-  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius)
+  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius || use_variable_inflation_ != use_variable_inflation ||
+      min_inflation_radius_ != min_inflation_radius || max_inflation_radius_ != max_inflation_radius ||
+      min_inflation_vel_ != min_inflation_vel || max_inflation_vel_ != max_inflation_vel)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -427,6 +430,13 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
     cell_inflation_radius_ = cellDistance(inflation_radius_);
     weight_ = cost_scaling_factor;
     need_reinflation_ = true;
+
+    use_variable_inflation_ = use_variable_inflation;
+    min_inflation_radius_ = min_inflation_radius;
+    max_inflation_radius_ = max_inflation_radius;
+    min_inflation_vel_ = min_inflation_vel;
+    max_inflation_vel_ = max_inflation_vel;
+
     computeCaches();
   }
 }

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -69,10 +69,10 @@ InflationLayer::InflationLayer()
   inflation_access_ = new boost::recursive_mutex();
 }
 
-void InflationLayer::vel_callback(const geometry_msgs::Twist::ConstPtr& msg)
+void InflationLayer::diff_drive_debug_info_callback(const lexxauto_msgs::DiffDriveEffortControllerDebug::ConstPtr& msg)
 {
   boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
-  vel_msg = *msg;
+  diff_drive_debug_info_msg = *msg;
 }
 
 void InflationLayer::onInitialize()
@@ -80,7 +80,8 @@ void InflationLayer::onInitialize()
   {
     boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
-    vel_sub = g_nh.subscribe<geometry_msgs::Twist>("/robot1/cmd_vel", 1, &InflationLayer::vel_callback, this);
+    diff_drive_debug_info_sub = g_nh.subscribe<lexxauto_msgs::DiffDriveEffortControllerDebug>
+      ("/robot1/diff_drive_effort_controller/debug_info", 1, &InflationLayer::diff_drive_debug_info_callback, this);
     current_ = true;
     if (seen_)
       delete[] seen_;
@@ -181,7 +182,7 @@ void InflationLayer::onFootprintChanged()
 double InflationLayer::calculate_variable_inflation_radius()
 {
   double variable_inflation_radius = min_inflation_radius_;
-  const double measured_velocity = vel_msg.linear.x;
+  const double measured_velocity = diff_drive_debug_info_msg.measured_twist_filtered.linear.x;
 
   if (std::abs(measured_velocity) < min_inflation_vel_)
   {

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -109,6 +109,20 @@ void InflationLayer::onInitialize()
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
   setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
+  std::cerr << "inflation radius: " << config.inflation_radius << std::endl;
+  std::cerr << "cost scaling factor: " << config.cost_scaling_factor << std::endl;
+  std::cerr << "use_variable_inflation: " << config.use_variable_inflation << std::endl;
+  std::cerr << "min_inflation_radius: " << config.min_inflation_radius << std::endl;
+  std::cerr << "max_inflation_radius: " << config.max_inflation_radius << std::endl;
+  std::cerr << "min_inflation_vel: " << config.min_inflation_vel << std::endl;
+  std::cerr << "max_inflation_vel: " << config.max_inflation_vel << std::endl;
+
+  boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
+  use_variable_inflation_ = config.use_variable_inflation;
+  min_inflation_radius_ = config.min_inflation_radius;
+  max_inflation_radius_ = config.max_inflation_radius;
+  min_inflation_vel_ = config.min_inflation_vel;
+  max_inflation_vel_ = config.min_inflation_vel;
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -178,16 +178,41 @@ void InflationLayer::onFootprintChanged()
             layered_costmap_->getFootprint().size(), inscribed_radius_, inflation_radius_);
 }
 
+double InflationLayer::calculate_variable_inflation_radius()
+{
+  double variable_inflation_radius = min_inflation_radius_;
+  const double measured_velocity = vel_msg.linear.x;
+
+  if (std::abs(measured_velocity) < min_inflation_vel_)
+  {
+    variable_inflation_radius = min_inflation_radius_;
+    ROS_INFO("inflation radius is min (%f) since velocity is low enough.", variable_inflation_radius);
+  }
+  else if (std::abs(measured_velocity) > max_inflation_vel_)
+  {
+    variable_inflation_radius = max_inflation_radius_;
+    ROS_INFO("inflation radius is max (%f) since velocity is large enough.", variable_inflation_radius);
+  }
+  else
+  {
+    variable_inflation_radius = (max_inflation_radius_ - min_inflation_radius_) /
+                                (max_inflation_vel_ - min_inflation_vel_) *
+                                std::abs(measured_velocity);
+    ROS_INFO("calculated inflation radius is %f.", variable_inflation_radius);
+  }
+
+  return variable_inflation_radius;
+}
+
 void InflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int min_i, int min_j, int max_i, int max_j)
 {
   boost::unique_lock < boost::recursive_mutex > lock(*inflation_access_);
 
-  double radius;
-  if (std::abs(vel_msg.linear.x) < 0.1) radius = 0.1;
-  else if (std::abs(vel_msg.linear.x) > 1.0) radius = 1.0;
-  else radius = vel_msg.linear.x;
-
-  setInflationParameters(radius, weight_);
+  if (use_variable_inflation_)
+  {
+    double variable_inflation_radius = calculate_variable_inflation_radius();
+    setInflationParameters(variable_inflation_radius, weight_);
+  }
 
   if (!enabled_ || (cell_inflation_radius_ == 0))
     return;

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -83,7 +83,7 @@ void InflationLayer::onInitialize()
     boost::unique_lock < boost::recursive_mutex > lock_i(*inflation_access_);
     ros::NodeHandle nh("~/" + name_), g_nh;
     diff_drive_debug_info_sub = g_nh.subscribe<lexxauto_msgs::DiffDriveEffortControllerDebug>
-      ("/robot1/diff_drive_effort_controller/debug_info", 1, &InflationLayer::diff_drive_debug_info_callback, this);
+      ("diff_drive_effort_controller/debug_info", 1, &InflationLayer::diff_drive_debug_info_callback, this);
     current_ = true;
     if (seen_)
       delete[] seen_;
@@ -116,7 +116,7 @@ void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, ui
   min_inflation_radius_ = config.min_inflation_radius;
   max_inflation_radius_ = config.max_inflation_radius;
   min_inflation_vel_ = config.min_inflation_vel;
-  max_inflation_vel_ = config.min_inflation_vel;
+  max_inflation_vel_ = config.max_inflation_vel;
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -344,6 +344,11 @@ void Costmap2DROS::copyParentParameters(const std::string& plugin_name, const st
   {
     move_parameter(nh, target_layer, "cost_scaling_factor", false);
     move_parameter(nh, target_layer, "inflation_radius", false);
+    move_parameter(nh, target_layer, "use_variable_inflation", false);
+    move_parameter(nh, target_layer, "min_inflation_radius", false);
+    move_parameter(nh, target_layer, "max_inflation_radius", false);
+    move_parameter(nh, target_layer, "min_inflation_vel", false);
+    move_parameter(nh, target_layer, "max_inflation_vel", false);
   }
 }
 

--- a/costmap_2d/test/inflation_tests_unit.cpp
+++ b/costmap_2d/test/inflation_tests_unit.cpp
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, LexxPluss, Inc.
+ * All rights reserved.
+ * 
+ */
+
+#include <gtest/gtest.h>
+#include <boost/make_shared.hpp>
+
+#define protected public
+#define private public
+#include <costmap_2d/inflation_layer.h>
+#undef private
+#undef protected
+
+using namespace costmap_2d;
+
+TEST(costmap, testCalculateVariableInflationRadius){
+  boost::shared_ptr<InflationLayer> ilayer = boost::make_shared<InflationLayer>();
+  double radius = 0.0;
+
+  ilayer->min_inflation_radius_ = 0.1;
+  ilayer->max_inflation_radius_ = 1.0;
+  ilayer->min_inflation_vel_ = 0.1;
+  ilayer->max_inflation_vel_ = 1.0;
+
+  ilayer->diff_drive_debug_info_msg.measured_twist_filtered.linear.x = 0.05;
+  radius = ilayer->calculate_variable_inflation_radius();
+  EXPECT_EQ(radius, ilayer->min_inflation_radius_);
+
+  ilayer->diff_drive_debug_info_msg.measured_twist_filtered.linear.x = 0.5;
+  radius = ilayer->calculate_variable_inflation_radius();
+  EXPECT_EQ(radius, 0.5);
+
+  ilayer->diff_drive_debug_info_msg.measured_twist_filtered.linear.x = 1.1;
+  radius = ilayer->calculate_variable_inflation_radius();
+  EXPECT_EQ(radius, ilayer->max_inflation_radius_);
+}
+
+int main(int argc, char** argv){
+  ros::init(argc, argv, "inflation_tests_unit");
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/costmap_2d/test/inflation_tests_unit.launch
+++ b/costmap_2d/test/inflation_tests_unit.launch
@@ -1,0 +1,4 @@
+<launch>
+  <test time-limit="300" test-name="inflation_tests_unit" pkg="costmap_2d" type="inflation_tests_unit">
+  </test>
+</launch>


### PR DESCRIPTION
related to AMRSW-241

**tests for robot**
- [x] robot can move at least 10 times with use_variable_inflation false
- [x] robot can move at least 3 times for each with use_variable_inflation true
  - check inflation radius change by debugging inflation value.
  - [x] for global costmap true, local costmap false
  - [x] for global costmap false, local costmap true
  - [x] for both true
  - [x] change the max_inflation radius and min_inflation_radius
  - [x] change the max_inflation_vel and min_infation_vel