### PR TITLE
[navigation] add missing depend

### DIFF
--- a/clear_costmap_recovery/CMakeLists.txt
+++ b/clear_costmap_recovery/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED
             pluginlib
             roscpp
             tf2_ros
+            lexxauto_msgs
         )
 
 find_package(Eigen3 REQUIRED)
@@ -29,6 +30,7 @@ catkin_package(
         pluginlib
         roscpp
         tf2_ros
+        lexxauto_msgs
 )
 
 add_library(clear_costmap_recovery src/clear_costmap_recovery.cpp)

--- a/clear_costmap_recovery/package.xml
+++ b/clear_costmap_recovery/package.xml
@@ -26,6 +26,7 @@
     <depend>pluginlib</depend>
     <depend>roscpp</depend>
     <depend>tf2_ros</depend>
+    <depend>lexxauto_msgs</depend>
 
     <test_depend>rostest</test_depend>
 
@@ -33,5 +34,3 @@
         <nav_core plugin="${prefix}/ccr_plugin.xml" />
     </export>
 </package>
-
-

--- a/move_slow_and_clear/CMakeLists.txt
+++ b/move_slow_and_clear/CMakeLists.txt
@@ -9,6 +9,7 @@ find_package(catkin REQUIRED
         nav_core
         pluginlib
         roscpp
+        lexxauto_msgs
         )
 
 

--- a/move_slow_and_clear/package.xml
+++ b/move_slow_and_clear/package.xml
@@ -25,11 +25,10 @@
     <depend>nav_core</depend>
     <depend>pluginlib</depend>
     <depend>roscpp</depend>
+    <depend>lexxauto_msgs</depend>
 
     <export>
         <nav_core plugin="${prefix}/recovery_plugin.xml" />
     </export>
 
 </package>
-
-


### PR DESCRIPTION
Add missing dependency. Without this PR, `catkin build` fails.

https://github.com/LexxPluss/LexxAuto/pull/2851