### PR TITLE
AMRSW-537 Make navigation Noetic compliant by removing tf

### DIFF
--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -1,6 +1,4 @@
-#!/usr/bin/env python
-
-from __future__ import print_function
+#!/usr/bin/env python3
 
 import sys
 import time

--- a/amcl/test/basic_localization.py
+++ b/amcl/test/basic_localization.py
@@ -11,18 +11,21 @@ import rospy
 import rostest
 
 import tf2_py as tf2
-import tf2_ros
+from tf2_ros import (
+    Buffer,
+    TransformListener
+)
 import PyKDL
 from std_srvs.srv import Empty
-
+from geometry_msgs.msg import Transform
 
 class TestBasicLocalization(unittest.TestCase):
     def setUp(self):
-        self.tf = None
-        self.target_x = None
-        self.target_y = None
-        self.target_a = None
-        self.tfBuffer = None
+        self.tf: Transform = None
+        self.target_x: float = None
+        self.target_y: float = None
+        self.target_a: float = None
+        self.tfBuffer: Buffer = None
         self.maxConnectivityExceptions = 5
         self.connectivityExceptions = 0
 
@@ -61,7 +64,7 @@ class TestBasicLocalization(unittest.TestCase):
             angle += 2*pi
         return fmod(angle, 2*pi) - pi
 
-    def compute_angle(self):
+    def compute_angle(self) -> float:
         rot = self.tf.rotation
         a_curr = PyKDL.Rotation.Quaternion(rot.x, rot.y, rot.z, rot.w).GetRPY()[2]
         a_diff = self.wrap_angle(a_curr - self.target_a)
@@ -88,8 +91,8 @@ class TestBasicLocalization(unittest.TestCase):
             global_localization()
 
         start_time = rospy.rostime.get_time()
-        self.tfBuffer = tf2_ros.Buffer()
-        listener = tf2_ros.TransformListener(self.tfBuffer)
+        self.tfBuffer = Buffer()
+        listener = TransformListener(self.tfBuffer)
 
         while (rospy.rostime.get_time() - start_time) < target_time:
             print('Waiting for end time %.6f (current: %.6f)' % (target_time, (rospy.rostime.get_time() - start_time)))

--- a/fake_localization/static_odom_broadcaster.py
+++ b/fake_localization/static_odom_broadcaster.py
@@ -11,9 +11,19 @@
 
 import rospy
 
-import tf
+from tf2_ros.transform_broadcaster import TransformBroadcaster
+from transforms3d.euler import euler2quat
 from nav_msgs.msg import Odometry
-from geometry_msgs.msg import Pose, Quaternion, Point
+from geometry_msgs.msg import (
+    Point,
+    Pose,
+    Quaternion,
+    Transform,
+    TransformStamped,
+    Vector3
+)
+from std_msgs.msg import Header
+
 
 
 def publishOdom():
@@ -22,23 +32,29 @@ def publishOdom():
     odom_frame_id = rospy.get_param("~odom_frame_id", "odom")
     publish_frequency = rospy.get_param("~publish_frequency", 10.0)
     pub = rospy.Publisher('odom', Odometry)
-    tf_pub = tf.TransformBroadcaster()
+    tf_pub = TransformBroadcaster()
 
     #TODO: static pose could be made configurable (cmd.line or parameters)
-    quat = tf.transformations.quaternion_from_euler(0, 0, 0)
+    quat = euler2quat(0, 0, 0)
+    quat = Quaternion(quat[1], quat[2], quat[3], quat[0])
 
     odom = Odometry()
     odom.header.frame_id = odom_frame_id
-    odom.pose.pose = Pose(Point(0, 0, 0), Quaternion(*quat))
+    odom.pose.pose = Pose(Point(0, 0, 0), quat)
 
     rospy.loginfo("Publishing static odometry from \"%s\" to \"%s\"", odom_frame_id, base_frame_id)
     r = rospy.Rate(publish_frequency)
     while not rospy.is_shutdown():
         odom.header.stamp = rospy.Time.now()
         pub.publish(odom)
-        tf_pub.sendTransform((0, 0, 0), quat,
-                             odom.header.stamp, base_frame_id, odom_frame_id)
+        t_stamped = TransformStamped(
+            Header(stamp=odom.header.stamp, frame_id=odom_frame_id),
+            base_frame_id,
+            Transform(Vector3(0, 0, 0), quat)
+        )
+        tf_pub.sendTransform(t_stamped)
         r.sleep()
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
[AMRSW-537](https://lexxpluss.atlassian.net/browse/AMRSW-537)
Along with LexxAuto, we need to change the `tf` references in Navigation repo

[AMRSW-537]: https://lexxpluss.atlassian.net/browse/AMRSW-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ