### PR TITLE
Amrcs 153 wani rotation

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -196,6 +196,8 @@ namespace dwa_local_planner {
       double latch_unlock_distance_;
       double cargo_timeout_sec_;
 
+      double cargo_limit_angle_deg_;
+      double current_cargo_angle_;
       bool is_cargo_enabled_;
       ros::Time cargo_angle_recv_time_;
   };

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -158,6 +158,8 @@ namespace dwa_local_planner {
       private_nh.param("cargo_timeout_sec", this->cargo_timeout_sec_, 1.0);
       private_nh.param("backward_rotate_time", this->backward_rotate_time_, 3.0);
 
+      private_nh.param("cargo_limit_angle_deg", this->cargo_limit_angle_deg_, 90.0);
+
       this->is_actuator_connect_ = false;
       this->rotate_to_goal_ = false;
       this->is_cargo_enabled_ = false;
@@ -473,6 +475,29 @@ namespace dwa_local_planner {
       double turn_turget_y = turn_target_pose.pose.position.y;
 
       double turn_turget_th = std::atan2(turn_turget_y - current_y, turn_turget_x - current_x);
+      double current_th = tf2::getYaw(this->current_pose_.pose.orientation);
+
+
+      if (this->is_cargo_enabled_)
+      {
+        // check target cargo angle
+        auto normalize = [](double angle) {
+          while (angle > M_PI) angle -= 2 * M_PI;
+          while (angle < -M_PI) angle += 2 * M_PI;
+          return angle;
+        };
+
+        double relative_cargo_angle_when_turned = normalize(this->current_cargo_angle_ - (turn_turget_th - current_th));
+
+        if (std::abs(relative_cargo_angle_when_turned) < this->cargo_limit_angle_deg_) {
+          if (relative_cargo_angle_when_turned > 0) {
+            turn_turget_th = normalize(current_th + this->current_cargo_angle_ - this->cargo_limit_angle_deg_);
+          } else {
+            turn_turget_th = normalize(current_th + this->current_cargo_angle_ + this->cargo_limit_angle_deg_);
+          }
+        }
+      }
+
       base_local_planner::LocalPlannerLimits limits = planner_util_.getCurrentLimits();
 
       bool was_rotate = startLatchedStopRotateController_.rotateToGoal(
@@ -485,7 +510,6 @@ namespace dwa_local_planner {
         limits,
         boost::bind(&DWAPlanner::checkTrajectory, dp_, _1, _2, _3));
 
-      double current_th = tf2::getYaw(this->current_pose_.pose.orientation);
       if (!was_rotate || std::abs(current_th - turn_turget_th) < (5.0 * M_PI / 180.0))
       {
         this->rotate_to_goal_ = false;
@@ -522,6 +546,7 @@ namespace dwa_local_planner {
 
   void DWAPlannerROS::cargo_angle_callback(const std_msgs::Float64::ConstPtr& msg)
   {
+    this->current_cargo_angle_ = msg->data;
     this->dp_->setCargoAngle(msg->data);
     this->goalLatchedStopRotateController_.setCargoAngle(msg->data);
     this->startLatchedStopRotateController_.setCargoAngle(msg->data);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -473,10 +473,10 @@ namespace dwa_local_planner {
         }
       }
       
-      double turn_turget_x = turn_target_pose.pose.position.x;
-      double turn_turget_y = turn_target_pose.pose.position.y;
+      double turn_target_x = turn_target_pose.pose.position.x;
+      double turn_target_y = turn_target_pose.pose.position.y;
 
-      double turn_turget_th = std::atan2(turn_turget_y - current_y, turn_turget_x - current_x);
+      double turn_target_th = std::atan2(turn_target_y - current_y, turn_target_x - current_x);
       double current_th = tf2::getYaw(this->current_pose_.pose.orientation);
 
 
@@ -489,14 +489,14 @@ namespace dwa_local_planner {
           return angle;
         };
 
-        double relative_cargo_angle_when_turned = normalize(this->current_cargo_angle_ - (turn_turget_th - current_th));
+        double relative_cargo_angle_when_turned = normalize(this->current_cargo_angle_ - (turn_target_th - current_th));
         double cargo_limit_angle_rad = this->cargo_limit_angle_deg_ * M_PI / 180.0;
 
         if (std::abs(relative_cargo_angle_when_turned) < cargo_limit_angle_rad) {
           if (relative_cargo_angle_when_turned > 0) {
-            turn_turget_th = normalize(current_th + this->current_cargo_angle_ - cargo_limit_angle_rad);
+            turn_target_th = normalize(current_th + this->current_cargo_angle_ - cargo_limit_angle_rad);
           } else {
-            turn_turget_th = normalize(current_th + this->current_cargo_angle_ + cargo_limit_angle_rad);
+            turn_target_th = normalize(current_th + this->current_cargo_angle_ + cargo_limit_angle_rad);
           }
         }
       }
@@ -506,14 +506,14 @@ namespace dwa_local_planner {
       bool was_rotate = startLatchedStopRotateController_.rotateToGoal(
         current_pose_,
         robot_vel,
-        turn_turget_th,
+        turn_target_th,
         cmd_vel,
         limits.getAccLimits(),
         dp_->getSimPeriod(),
         limits,
         boost::bind(&DWAPlanner::checkTrajectory, dp_, _1, _2, _3));
 
-      if (!was_rotate || std::abs(current_th - turn_turget_th) < (5.0 * M_PI / 180.0))
+      if (!was_rotate || std::abs(current_th - turn_target_th) < (5.0 * M_PI / 180.0))
       {
         this->rotate_to_goal_ = false;
       }

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -488,12 +488,13 @@ namespace dwa_local_planner {
         };
 
         double relative_cargo_angle_when_turned = normalize(this->current_cargo_angle_ - (turn_turget_th - current_th));
+        double cargo_limit_angle_rad = this->cargo_limit_angle_deg_ * M_PI / 180.0;
 
-        if (std::abs(relative_cargo_angle_when_turned) < this->cargo_limit_angle_deg_) {
+        if (std::abs(relative_cargo_angle_when_turned) < cargo_limit_angle_rad) {
           if (relative_cargo_angle_when_turned > 0) {
-            turn_turget_th = normalize(current_th + this->current_cargo_angle_ - this->cargo_limit_angle_deg_);
+            turn_turget_th = normalize(current_th + this->current_cargo_angle_ - cargo_limit_angle_rad);
           } else {
-            turn_turget_th = normalize(current_th + this->current_cargo_angle_ + this->cargo_limit_angle_deg_);
+            turn_turget_th = normalize(current_th + this->current_cargo_angle_ + cargo_limit_angle_rad);
           }
         }
       }


### PR DESCRIPTION
Close AMRCS-153

# Implementation
* AMRモードの初期回転時に、CargoAngleが90°未満になる経路が出された時に、90°に収まる経路に変更する
* 

# Tests
* 鋭角の経路が出るような中間ゴールを設定し、走行させて90°以内にならないことを確認
* AMRの位置とゴールの間に台車が来るような経路を設定して、90°以内にならないことを確認
* https://lexxpluss.slack.com/archives/C02KPDNKP3N/p1707277184561419