### PR TITLE
[AMRCS-157] add fixed cargo option.

### DIFF
--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -195,9 +195,22 @@ namespace dwa_local_planner {
       bool is_force_update_;
       double latch_unlock_distance_;
       double cargo_timeout_sec_;
+      std::string cargo_mode_;
 
+      bool is_cargo_fixed_;
       bool is_cargo_enabled_;
       ros::Time cargo_angle_recv_time_;
+  };
+  enum actuator_status
+  {
+    ACT_LOW = 0,
+    ACT_LOW_TO_MID,
+    ACT_MID,
+    ACT_MID_TO_MID2,
+    ACT_MID2,
+    ACT_MID2_TO_HIGH,
+    ACT_HIGH,
+    ACT_STOP
   };
 };
 #endif

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -541,6 +541,12 @@ namespace dwa_local_planner {
     {
       this->is_cargo_fixed_ = true;
     }
+    else
+    {
+      ROS_WARN_STREAM_ONCE("DWAPlannerROS: Unknown cargo_mode; using 'loading' :: " << this->cargo_mode_);
+      this->is_cargo_fixed_ = true;
+    }
+
   }
 
   void DWAPlannerROS::cargo_angle_callback(const std_msgs::Float64::ConstPtr& msg)
@@ -552,6 +558,10 @@ namespace dwa_local_planner {
     {
       this->is_cargo_enabled_ = true;
       this->cargo_angle_recv_time_ = ros::Time::now();
+    }
+    else
+    {
+      this->is_cargo_enabled_ = false;
     }
   }
 

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -157,10 +157,12 @@ namespace dwa_local_planner {
       private_nh.param("latch_unlock_distance", this->latch_unlock_distance_, 1.0);
       private_nh.param("cargo_timeout_sec", this->cargo_timeout_sec_, 1.0);
       private_nh.param("backward_rotate_time", this->backward_rotate_time_, 3.0);
+      private_nh.param("cargo_mode", this->cargo_mode_, std::string("loading")); // loading or towing or wani
 
       this->is_actuator_connect_ = false;
       this->rotate_to_goal_ = false;
       this->is_cargo_enabled_ = false;
+      this->is_cargo_fixed_ = false;
     }
     else{
       ROS_WARN("This planner has already been initialized, doing nothing.");
@@ -518,6 +520,27 @@ namespace dwa_local_planner {
   void DWAPlannerROS::actuator_position_callback(const lexxauto_msgs::ActuatorStatus::ConstPtr& msg)
   {
     this->is_actuator_connect_ = msg->connect;
+
+    // The decision should be delegated to the node responsible for Cargo Status at some point. => AMRCS-174
+    this->is_cargo_fixed_ = false;
+    if (this->cargo_mode_ == "wani")
+    {
+      if (actuator_status::ACT_MID2 <= msg->position[0])
+      {
+        this->is_cargo_fixed_ = true;
+      }
+    }
+    else if (this->cargo_mode_ == "towing")
+    {
+      if (!msg->connect)
+      {
+        this->is_cargo_fixed_ = true;
+      }
+    }
+    else if (this->cargo_mode_ == "loading")
+    {
+      this->is_cargo_fixed_ = true;
+    }
   }
 
   void DWAPlannerROS::cargo_angle_callback(const std_msgs::Float64::ConstPtr& msg)
@@ -525,8 +548,11 @@ namespace dwa_local_planner {
     this->dp_->setCargoAngle(msg->data);
     this->goalLatchedStopRotateController_.setCargoAngle(msg->data);
     this->startLatchedStopRotateController_.setCargoAngle(msg->data);
-    this->is_cargo_enabled_ = true;
-    this->cargo_angle_recv_time_ = ros::Time::now();
+    if (!this->is_cargo_fixed_)
+    {
+      this->is_cargo_enabled_ = true;
+      this->cargo_angle_recv_time_ = ros::Time::now();
+    }
   }
 
   void DWAPlannerROS::check_cargo_angle()
@@ -539,6 +565,7 @@ namespace dwa_local_planner {
         this->is_cargo_enabled_ = false;
       }
     }
+    ROS_INFO_STREAM("DWAPlannerROS :: is_cargo_enabled :: " << this->is_cargo_enabled_);
 
     this->dp_->setCargoEnabled(this->is_cargo_enabled_);
     this->goalLatchedStopRotateController_.setCargoEnabled(this->is_cargo_enabled_);


### PR DESCRIPTION
Close AMRCS-157
※ C対応の為優先度高
https://lexxpluss.slack.com/archives/C054XU7132B/p1707739314966779?thread_ts=1707354310.988039&cid=C054XU7132B

# Implementation
* cargo_enabled == true の場合に、プランナではその場回転の際にFootprintを回転させていなかった
* 荷台に物を乗せる動作の場合、アクチュエータの上下に関係なくFootprintは回転すべき
* 1本牽引時の動作の場合、アクチュエータを降ろしているときはFootprintを回転させ、アクチュエータが上がっているときはFootprintを回転させないべき
* WaniGripperの動作の場合、中央アクチュエータを降ろしているときはFootprintを回転させず、中央アクチュエータが上がっているときはFootprintを回転させるべき

# Tests
* Footprintが回転することによって、その場回転時に障害物があった際に停止することを確認
