### PR TITLE
[AMRCS-154] add margin for Infration to avoid obstacles with enough time to spare.

### DIFF
--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -9,4 +9,7 @@ gen.add("cost_scaling_factor", double_t, 0, "A scaling factor to apply to cost v
 gen.add("inflation_radius", double_t, 0, "The radius in meters to which the map inflates obstacle cost values.", 0.55, 0, 50)
 gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False)
 
+gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
+gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
+
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))

--- a/costmap_2d/cfg/VariableInflationPlugin.cfg
+++ b/costmap_2d/cfg/VariableInflationPlugin.cfg
@@ -14,4 +14,7 @@ gen.add("max_inflation_radius", double_t, 0, "Maximum inflation radius", 0.6, 0.
 gen.add("min_inflation_vel", double_t, 0, "Minimum inflation velocity to activate variable inflation", 0.3, 0.0, 1.0)
 gen.add("max_inflation_vel", double_t, 0, "Maximum inflation velocity to activate variable inflation", 0.7, 0.0, 2.0)
 
+gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
+gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
+
 exit(gen.generate("costmap_2d", "costmap_2d", "VariableInflationPlugin"))

--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -231,11 +231,8 @@ public:
    * getUnpaddedRobotFootprint(). */
   void setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint);
 
-  void actuator_position_callback(const lexxauto_msgs::ActuatorStatus::ConstPtr& msg);
   void footprint_callback(const geometry_msgs::Polygon::ConstPtr& msg);
 
-  //std::vector<geometry_msgs::Point>
-  void dynamicFootprintFromParams();
 
   void load_footprints(ros::NodeHandle& nh, std::vector<geometry_msgs::Point>& extended_footprint, std::vector<geometry_msgs::Point>& original_footprint);
 protected:
@@ -277,16 +274,10 @@ private:
   ros::Subscriber footprint_sub_;
   ros::Subscriber truck_footprint_sub_;
   ros::Publisher footprint_pub_;
-  ros::Subscriber actuator_position_sub_;////
   std::vector<geometry_msgs::Point> unpadded_footprint_;
   std::vector<geometry_msgs::Point> padded_footprint_;
   float footprint_padding_;
   costmap_2d::Costmap2DConfig old_config_;
-  std::mutex footprint_mutex_;
-
-  lexxauto_msgs::ActuatorStatus actuator_position;
-  std::vector<geometry_msgs::Point> extended_footprint;
-  std::vector<geometry_msgs::Point> original_footprint;
 };
 
 // class Costmap2DROS

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -106,8 +106,10 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_)
+    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
+    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+      cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {
       // make sure cost falls off by Euclidean distance
@@ -122,8 +124,11 @@ public:
    * @brief Change the values of the inflation radius parameters
    * @param inflation_radius The new inflation radius
    * @param cost_scaling_factor The new weight
+   * @param impassable_margin The margin to apply to no entry cost values.
+   * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
    */
-  void setInflationParameters(double inflation_radius, double cost_scaling_factor);
+  void setInflationParameters(double inflation_radius, double cost_scaling_factor,
+                              double impassable_margin, double path_avoidance_margin);
 
 protected:
   virtual void onFootprintChanged();
@@ -132,6 +137,8 @@ protected:
   double resolution_;
   double inflation_radius_;
   double inscribed_radius_;
+  double path_avoidance_margin_;
+  double impassable_margin_;
   double weight_;
   bool inflate_unknown_;
 

--- a/costmap_2d/include/costmap_2d/variable_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/variable_inflation_layer.h
@@ -111,8 +111,10 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_)
+    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
+    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+      cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {
       // make sure cost falls off by Euclidean distance
@@ -131,13 +133,17 @@ public:
    * @param max_inflation_radius The maximum inflation radius
    * @param min_inflation_vel The minimum velocity to activate variable inflation
    * @param max_inflation_vel The maximum velocity to activate variable inflation
+   * @param impassable_margin The margin to apply to no entry cost values.
+   * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
    */
   void setInflationParameters(double inflation_radius,
                               double cost_scaling_factor,
                               double min_inflation_radius,
                               double max_inflation_radius,
                               double min_inflation_vel,
-                              double max_inflation_vel);
+                              double max_inflation_vel,
+                              double impassable_margin,
+                              double path_avoidance_margin);
 
 protected:
   virtual void onFootprintChanged();
@@ -153,6 +159,8 @@ protected:
   double max_inflation_radius_ = 0.5;
   double min_inflation_vel_ = 0.2;
   double max_inflation_vel_ = 0.6;
+  double path_avoidance_margin_;
+  double impassable_margin_;
 
 private:
   /**

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -57,6 +57,8 @@ InflationLayer::InflationLayer()
   , inflate_unknown_(false)
   , cell_inflation_radius_(0)
   , cached_cell_inflation_radius_(0)
+  , path_avoidance_margin_(0)
+  , impassable_margin_(0)
   , dsrv_(NULL)
   , seen_(NULL)
   , cached_costs_(NULL)
@@ -100,7 +102,7 @@ void InflationLayer::onInitialize()
 
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
-  setInflationParameters(config.inflation_radius, config.cost_scaling_factor);
+  setInflationParameters(config.inflation_radius, config.cost_scaling_factor, config.path_avoidance_margin, config.impassable_margin);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -364,9 +366,11 @@ void InflationLayer::deleteKernels()
   }
 }
 
-void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor)
+void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor,
+                                            double path_avoidance_margin, double impassable_margin)
 {
-  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius)
+  if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
+      path_avoidance_margin_ != path_avoidance_margin || impassable_margin_ != impassable_margin)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -375,6 +379,8 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
     inflation_radius_ = inflation_radius;
     cell_inflation_radius_ = cellDistance(inflation_radius_);
     weight_ = cost_scaling_factor;
+    path_avoidance_margin_ = path_avoidance_margin;
+    impassable_margin_ = impassable_margin;
     need_reinflation_ = true;
     computeCaches();
   }

--- a/costmap_2d/plugins/variable_inflation_layer.cpp
+++ b/costmap_2d/plugins/variable_inflation_layer.cpp
@@ -57,6 +57,8 @@ VariableInflationLayer::VariableInflationLayer()
   , inflate_unknown_(false)
   , cell_inflation_radius_(0)
   , cached_cell_inflation_radius_(0)
+  , path_avoidance_margin_(0)
+  , impassable_margin_(0)
   , dsrv_(NULL)
   , seen_(NULL)
   , cached_costs_(NULL)
@@ -112,7 +114,8 @@ void VariableInflationLayer::reconfigureCB(costmap_2d::VariableInflationPluginCo
 {
   setInflationParameters(config.inflation_radius, config.cost_scaling_factor,
                          config.min_inflation_radius, config.max_inflation_radius,
-                         config.min_inflation_vel, config.max_inflation_vel);
+                         config.min_inflation_vel, config.max_inflation_vel,
+                         config.impassable_margin, config.path_avoidance_margin);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -219,7 +222,8 @@ void VariableInflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int
   double variable_inflation_radius = calculate_variable_inflation_radius();
   setInflationParameters(variable_inflation_radius, weight_,
                          min_inflation_radius_, max_inflation_radius_,
-                         min_inflation_vel_, max_inflation_vel_);
+                         min_inflation_vel_, max_inflation_vel_,
+                         impassable_margin_, path_avoidance_margin_);
 
   if (!enabled_ || (cell_inflation_radius_ == 0))
     return;
@@ -416,11 +420,14 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
                                                     double min_inflation_radius,
                                                     double max_inflation_radius,
                                                     double min_inflation_vel,
-                                                    double max_inflation_vel)
+                                                    double max_inflation_vel,
+                                                    double impassable_margin,
+                                                    double path_avoidance_margin)
 {
   if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
       min_inflation_radius_ != min_inflation_radius || max_inflation_radius_ != max_inflation_radius ||
-      min_inflation_vel_ != min_inflation_vel || max_inflation_vel_ != max_inflation_vel)
+      min_inflation_vel_ != min_inflation_vel || max_inflation_vel_ != max_inflation_vel ||
+      impassable_margin_ != impassable_margin || path_avoidance_margin_ != path_avoidance_margin)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -429,13 +436,14 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
     inflation_radius_ = inflation_radius;
     cell_inflation_radius_ = cellDistance(inflation_radius_);
     weight_ = cost_scaling_factor;
-    need_reinflation_ = true;
 
     min_inflation_radius_ = min_inflation_radius;
     max_inflation_radius_ = max_inflation_radius;
     min_inflation_vel_ = min_inflation_vel;
     max_inflation_vel_ = max_inflation_vel;
-
+    path_avoidance_margin_ = path_avoidance_margin;
+    impassable_margin_ = impassable_margin;
+    need_reinflation_ = true;
     computeCaches();
   }
 }

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -152,7 +152,6 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
 
   private_nh.param(topic_param, topic, std::string("footprint"));
   footprint_sub_ = private_nh.subscribe(topic, 1, &Costmap2DROS::setUnpaddedRobotFootprintPolygon, this);
-  truck_footprint_sub_ = nh.subscribe<geometry_msgs::Polygon>("raw_footprint", 1, &Costmap2DROS::footprint_callback, this);
 
   if (!private_nh.searchParam("published_footprint_topic", topic_param))
   {
@@ -161,17 +160,14 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
 
   private_nh.param(topic_param, topic, std::string("oriented_footprint"));
   footprint_pub_ = private_nh.advertise<geometry_msgs::PolygonStamped>("footprint", 1);
-  actuator_position_sub_ = private_nh.subscribe("actuator_position", 10, &Costmap2DROS::actuator_position_callback, this);
 
   {
-    std::lock_guard<std::mutex> lock(footprint_mutex_);
-    original_footprint = makeFootprintFromParams(private_nh, "footprint");
-    extended_footprint = makeFootprintFromParams(private_nh, "extended_footprint");
+    std::vector<geometry_msgs::Point> new_footprint = makeFootprintFromParams(private_nh, "footprint");
 
-    if(original_footprint.empty() || extended_footprint.empty()) {
+    if(new_footprint.empty()) {
       ROS_ERROR("empty vector loaded");
     }
-    setUnpaddedRobotFootprint(original_footprint);
+    setUnpaddedRobotFootprint(new_footprint);
   }
 
   publisher_ = new Costmap2DPublisher(&private_nh, layered_costmap_->getCostmap(), global_frame_, "costmap",
@@ -194,34 +190,30 @@ Costmap2DROS::Costmap2DROS(const std::string& name, tf2_ros::Buffer& tf) :
 
 void Costmap2DROS::setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon& footprint)
 {
-  setUnpaddedRobotFootprint(toPointVector(footprint));
-}
+  std::vector<geometry_msgs::Point> points = toPointVector(footprint);
 
-void Costmap2DROS::footprint_callback(const geometry_msgs::Polygon::ConstPtr& msg)
-{
-  std::lock_guard<std::mutex> lock(footprint_mutex_);
-  extended_footprint = toPointVector(*msg);
-}
+  // check if the footprint is the same as the one we already have
+  bool is_changed = false;
+  if (points.size() != unpadded_footprint_.size())
+  {
+    is_changed = true;
+  }
+  else
+  {
+    for (unsigned int i = 0; i < points.size(); i++)
+    {
+      if (points[i].x != unpadded_footprint_[i].x || points[i].y != unpadded_footprint_[i].y)
+      {
+        is_changed = true;
+        break;
+      }
+    }
+  }
 
-void Costmap2DROS::actuator_position_callback(const lexxauto_msgs::ActuatorStatus::ConstPtr& msg)
-{
-  actuator_position = *msg;
-}
-
-
-//std::vector<geometry_msgs::Point> Costmap2DROS::dynamicFootprintFromParams(ros::NodeHandle& nh)
-void Costmap2DROS::dynamicFootprintFromParams()
-{
-  std::lock_guard<std::mutex> lock(footprint_mutex_);
-  std::string full_param_name;
-  std::string full_radius_param_name;
-  std::vector<geometry_msgs::Point> points;
-  ros::NodeHandle global_map_nh("/move_base/global_costmap");
-  ros::NodeHandle local_map_nh("/move_base/local_costmap");
-
-  writeFootprintToParam(global_map_nh, extended_footprint);
-  writeFootprintToParam(local_map_nh, extended_footprint);
-  setUnpaddedRobotFootprint(extended_footprint);
+  if (is_changed)
+  {
+    setUnpaddedRobotFootprint(points);
+  }
 }
 
 Costmap2DROS::~Costmap2DROS()
@@ -439,11 +431,8 @@ void Costmap2DROS::readFootprintFromConfig(const costmap_2d::Costmap2DConfig &ne
   }
   else
   {
-    std::lock_guard<std::mutex> lock(footprint_mutex_);
     // robot_radius may be 0, but that must be intended at this point.
-    original_footprint = makeFootprintFromRadius(new_config.robot_radius);
-    extended_footprint = makeFootprintFromRadius(new_config.robot_radius);
-    setUnpaddedRobotFootprint(original_footprint);
+    setUnpaddedRobotFootprint(makeFootprintFromRadius(new_config.robot_radius));
   }
 }
 
@@ -499,8 +488,6 @@ void Costmap2DROS::mapUpdateLoop(double frequency)
     struct timeval start, end;
     double start_t, end_t, t_diff;
     gettimeofday(&start, NULL);
-
-    dynamicFootprintFromParams();
 
     updateMap();
 

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -194,6 +194,7 @@ void Costmap2DROS::setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon
 
   // check if the footprint is the same as the one we already have
   bool is_changed = false;
+  constexpr double EPSILON = 1e-6;
   if (points.size() != unpadded_footprint_.size())
   {
     is_changed = true;
@@ -202,7 +203,8 @@ void Costmap2DROS::setUnpaddedRobotFootprintPolygon(const geometry_msgs::Polygon
   {
     for (unsigned int i = 0; i < points.size(); i++)
     {
-      if (points[i].x != unpadded_footprint_[i].x || points[i].y != unpadded_footprint_[i].y)
+      if (EPSILON < std::abs(points[i].x - unpadded_footprint_[i].x)
+        || EPSILON < std::abs(points[i].y - unpadded_footprint_[i].y))
       {
         is_changed = true;
         break;

--- a/global_planner/include/global_planner/dijkstra.h
+++ b/global_planner/include/global_planner/dijkstra.h
@@ -85,7 +85,7 @@ class DijkstraExpansion : public Expander {
 
         float getCost(unsigned char* costs, int n) {
             float c = costs[n];
-            if (c < lethal_cost_ - 1 || (unknown_ && c==255)) {
+            if (c < lethal_cost_ || (unknown_ && c==255)) {
                 c = c * factor_ + neutral_cost_;
                 if (c >= lethal_cost_)
                     c = lethal_cost_ - 1;


### PR DESCRIPTION
Close AMRCS-154


# Implementation
Costmapの計算時に障害物に近い経路をGlobalPlannerが生成していることで、障害物に引っかかって進めない事がある。
パラメータを追加する事によって、少し離れた経路を生成させやすくする事が出来る機能を追加した。

また、以前は可変Footprintの判定をCostmap内で行っていたが、現在は外部から送信されるためCostmap2D上で判定をする必要がなくなっている。
過去のコードが残っている状態だった為、Footprint変更時に不要な処理が実行されている。
検証時に、Costmap生成のパフォーマンスに問題があった為、過去の不要な処理を除去した。
パフォーマンス問題はテスト用のスクリプトに問題があり、Cosmap2D上の処理自体に問題は無かったが、
Cosmap2Dの処理時間が向上したため、変化点としては残している。

修正前： Global cost map=平均 3.2ms Local cost map=平均 1.7ms
修正後： Global cost map=平均 2.1ms Local cost map=平均 0.3ms

# Tests
動作確認動画
https://lexxpluss.slack.com/archives/C02KPDNKP3N/p1708672360660689?thread_ts=1708499364.680349&cid=C02KPDNKP3N

* 目的値との間に障害物がある、狭いコースを準備して走行出来ることを確認
* 追加したパラメータを調整することで走行に改善が見られることを確認

----

調査した結果と変更内容のドキュメントは以下になります。
https://www.notion.so/lexxpluss/Costmap-2D-Behavior-mainly-about-global-costmap-936fc687c49a40d6bcfa1957d74ab2dd?pvs=4