### PR TITLE
[AMRCS-372] limit scan_hi pgm for amcl 

### DIFF
--- a/amcl/src/amcl_node.cpp
+++ b/amcl/src/amcl_node.cpp
@@ -473,7 +473,7 @@ AmclNode::AmclNode() :
   private_nh_.param("update_min_a", a_thresh_, M_PI/6.0);
   private_nh_.param("odom_frame_id", odom_frame_id_, std::string("odom"));
   private_nh_.param("base_frame_id", base_frame_id_, std::string("base_link"));
-  private_nh_.param("global_frame_id", global_frame_id_, std::string("map"));
+  private_nh_.param("global_frame_id", global_frame_id_, std::string("map_amcl"));
   private_nh_.param("resample_interval", resample_interval_, 2);
   private_nh_.param("selective_resampling", selective_resampling_, false);
   double tmp_tol;
@@ -537,7 +537,7 @@ AmclNode::AmclNode() :
   initial_pose_sub_ = nh_.subscribe("initialpose", 2, &AmclNode::initialPoseReceived, this);
 
   if(use_map_topic_) {
-    map_sub_ = nh_.subscribe("map", 1, &AmclNode::mapReceived, this);
+    map_sub_ = nh_.subscribe("map_amcl", 1, &AmclNode::mapReceived, this);
     ROS_INFO("Subscribed to map topic.");
   } else {
     requestMap();


### PR DESCRIPTION
closes AMRCS-372

Until now, we use the same hi intensity PGM (map) file for all nodes including navigation which is not ideal.
So, this PR fixes the issue and limits the use of this PGM file only by AMCL node for localization.
Other nodes will use the scan version of the map PGM file.

TESTS:
- [ ] create test PGM files for klab (both scan and scan_hi)
- [ ] verify that path planning following scan version of the PGM file
- [ ] test scan_hi zoning
- [ ] test full scan_hi feature