### PR TITLE
Test skip matsuda 240801a

### DIFF
--- a/base_local_planner/include/base_local_planner/local_planner_util.h
+++ b/base_local_planner/include/base_local_planner/local_planner_util.h
@@ -94,6 +94,8 @@ public:
 
   bool setPlan(const std::vector<geometry_msgs::PoseStamped>& orig_global_plan);
 
+  void clearPlan() { global_plan_.clear(); }
+
   bool getLocalPlan(const geometry_msgs::PoseStamped& global_pose, std::vector<geometry_msgs::PoseStamped>& transformed_plan);
 
   costmap_2d::Costmap2D* getCostmap();

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner_ros.h
@@ -135,6 +135,7 @@ namespace dwa_local_planner {
 
       // feature switch flag
       bool use_carrying_manager_;
+      bool use_clear_plan_;
 
       /**
        * @brief Callback to update the local planner's parameters based on dynamic reconfigure

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -268,6 +268,7 @@ namespace dwa_local_planner {
         return false;
       }
 
+      planner_util_.clearPlan();
       ROS_INFO("goal_pose x %f, goal_pose y %f", goal_pose.pose.position.x, goal_pose.pose.position.y);
       ROS_INFO("current_pose x %f, current_pose y %f", current_pose_.pose.position.x, current_pose_.pose.position.y);
       ROS_INFO("xy_goal_tolerance : %f, d : %f", xy_goal_tolerance, d);

--- a/dwa_local_planner/src/dwa_planner_ros.cpp
+++ b/dwa_local_planner/src/dwa_planner_ros.cpp
@@ -161,6 +161,8 @@ namespace dwa_local_planner {
       dynamic_reconfigure::Server<DWAPlannerConfig>::CallbackType cb = boost::bind(&DWAPlannerROS::reconfigureCB, this, _1, _2);
       dsrv_->setCallback(cb);
 
+      private_nh.param("use_clear_plan", this->use_clear_plan_, true);
+
       private_nh.param("rotate_target_distance", this->rotate_target_distance_, 1.0);
       private_nh.param("rotate_start_threshold_vel", this->rotate_start_threshold_vel_, 0.1);
       private_nh.param("rotate_start_threshold_angular_vel", this->rotate_start_threshold_angular_vel_, 0.05);
@@ -268,7 +270,7 @@ namespace dwa_local_planner {
         return false;
       }
 
-      planner_util_.clearPlan();
+      if (use_clear_plan_) planner_util_.clearPlan();
       ROS_INFO("goal_pose x %f, goal_pose y %f", goal_pose.pose.position.x, goal_pose.pose.position.y);
       ROS_INFO("current_pose x %f, current_pose y %f", current_pose_.pose.position.x, current_pose_.pose.position.y);
       ROS_INFO("xy_goal_tolerance : %f, d : %f", xy_goal_tolerance, d);

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -106,6 +106,7 @@ namespace move_base {
       bool executeCycle(geometry_msgs::PoseStamped& goal, std::vector<geometry_msgs::PoseStamped>& global_plan);
 
     private:
+      double new_global_plan_delay_sec_ = 0.0;
       int detect_motion_stuck_count_ = 0;
       double pre_body_x_ = 0;
       double pre_body_y_ = 0;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -101,6 +101,8 @@ namespace move_base {
     private_nh.param("detect_motion_abs_vx", detect_motion_abs_vx_, 0.05);
     private_nh.param("detect_motion_abs_wz", detect_motion_abs_wz_, 5 * M_PI / 180);
 
+    private_nh.param("new_global_plan_delay_sec", new_global_plan_delay_sec_, 0.0);
+
     //set up plan triple buffer
     planner_plan_ = new std::vector<geometry_msgs::PoseStamped>();
     latest_plan_ = new std::vector<geometry_msgs::PoseStamped>();
@@ -758,6 +760,8 @@ namespace move_base {
 
     current_goal_pub_.publish(goal);
     std::vector<geometry_msgs::PoseStamped> global_plan;
+
+    ros::Duration(new_global_plan_delay_sec_).sleep();
 
     ros::Rate r(controller_frequency_);
     if(shutdown_costmaps_){


### PR DESCRIPTION
AMRCS-385

# Description
- Add clearing plan in reaching AMR goal.
- Add delay on new plan coming.

# Tests
## Environment and test items1
local_planner_params.yaml
```
use_clear_plan: true
```
move_base_params.yaml
```
new_global_plan_delay_sec: 0.05
```
- [x] Robot moves to AMR goal 10 times.

## Environment and test items2
local_planner_params.yaml
```
use_clear_plan: true
```
move_base_params.yaml
```
new_global_plan_delay_sec: 0.05
```
- [x] Robot moves to AMR goal 1 times.