### PR TITLE
Amrsw 1577 local inflation

### DIFF
--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -11,5 +11,6 @@ gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False
 
 gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
 gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
+gen.add("local_costmap", bool_t, 0, "Whether to use it for local costmap", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))

--- a/costmap_2d/cfg/InflationPlugin.cfg
+++ b/costmap_2d/cfg/InflationPlugin.cfg
@@ -11,6 +11,6 @@ gen.add("inflate_unknown", bool_t, 0, "Whether to inflate unknown cells.", False
 
 gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
 gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
-gen.add("local_costmap", bool_t, 0, "Whether to use it for local costmap", False)
+gen.add("disable_inscribed_inflated_obstacle", bool_t, 0, "Disable inscribed inflated obstacle.", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "InflationPlugin"))

--- a/costmap_2d/cfg/VariableInflationPlugin.cfg
+++ b/costmap_2d/cfg/VariableInflationPlugin.cfg
@@ -16,6 +16,6 @@ gen.add("max_inflation_vel", double_t, 0, "Maximum inflation velocity to activat
 
 gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
 gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
-gen.add("local_costmap", bool_t, 0, "Whether to use it for local costmap", False)
+gen.add("disable_inscribed_inflated_obstacle", bool_t, 0, "Disable inscribed inflated obstacle.", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "VariableInflationPlugin"))

--- a/costmap_2d/cfg/VariableInflationPlugin.cfg
+++ b/costmap_2d/cfg/VariableInflationPlugin.cfg
@@ -16,5 +16,6 @@ gen.add("max_inflation_vel", double_t, 0, "Maximum inflation velocity to activat
 
 gen.add("impassable_margin", double_t, 0, "The margin to apply to no entry cost values.", 0.0, 0, 10)
 gen.add("path_avoidance_margin", double_t, 0, "The margin to apply to path distance when avoiding obstacles.", 0.0, 0, 10)
+gen.add("local_costmap", bool_t, 0, "Whether to use it for local costmap", False)
 
 exit(gen.generate("costmap_2d", "costmap_2d", "VariableInflationPlugin"))

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -106,9 +106,9 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_)
+    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {
@@ -126,9 +126,11 @@ public:
    * @param cost_scaling_factor The new weight
    * @param impassable_margin The margin to apply to no entry cost values.
    * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
+   * @param local_costmap Whether to use it for local cost mapping
    */
   void setInflationParameters(double inflation_radius, double cost_scaling_factor,
-                              double impassable_margin, double path_avoidance_margin);
+                              double impassable_margin, double path_avoidance_margin,
+                              bool local_costmap);
 
 protected:
   virtual void onFootprintChanged();
@@ -140,6 +142,7 @@ protected:
   double path_avoidance_margin_;
   double impassable_margin_;
   double weight_;
+  bool local_costmap_;
   bool inflate_unknown_;
 
 private:

--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -106,9 +106,9 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
+    else if (!disable_inscribed_inflated_obstacle_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
-    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+    else if (!disable_inscribed_inflated_obstacle_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {
@@ -126,11 +126,11 @@ public:
    * @param cost_scaling_factor The new weight
    * @param impassable_margin The margin to apply to no entry cost values.
    * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
-   * @param local_costmap Whether to use it for local cost mapping
+   * @param disable_inscribed_inflated_obstacle Disable inscribed inflated obstacle.
    */
   void setInflationParameters(double inflation_radius, double cost_scaling_factor,
                               double impassable_margin, double path_avoidance_margin,
-                              bool local_costmap);
+                              bool disable_inscribed_inflated_obstacle);
 
 protected:
   virtual void onFootprintChanged();
@@ -142,7 +142,7 @@ protected:
   double path_avoidance_margin_;
   double impassable_margin_;
   double weight_;
-  bool local_costmap_;
+  bool disable_inscribed_inflated_obstacle_;
   bool inflate_unknown_;
 
 private:

--- a/costmap_2d/include/costmap_2d/variable_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/variable_inflation_layer.h
@@ -111,9 +111,9 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
+    else if (!disable_inscribed_inflated_obstacle_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
-    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+    else if (!disable_inscribed_inflated_obstacle_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {
@@ -135,7 +135,7 @@ public:
    * @param max_inflation_vel The maximum velocity to activate variable inflation
    * @param impassable_margin The margin to apply to no entry cost values.
    * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
-   * @param local_costmap Whether to use it for local cost mapping
+   * @param disable_inscribed_inflated_obstacle Disable inscribed inflated obstacle.
    */
   void setInflationParameters(double inflation_radius,
                               double cost_scaling_factor,
@@ -145,7 +145,7 @@ public:
                               double max_inflation_vel,
                               double impassable_margin,
                               double path_avoidance_margin,
-                              bool local_costmap);
+                              bool disable_inscribed_inflated_obstacle);
 
 protected:
   virtual void onFootprintChanged();
@@ -163,7 +163,7 @@ protected:
   double max_inflation_vel_ = 0.6;
   double path_avoidance_margin_;
   double impassable_margin_;
-  bool local_costmap_;
+  bool disable_inscribed_inflated_obstacle_;
 
 private:
   /**

--- a/costmap_2d/include/costmap_2d/variable_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/variable_inflation_layer.h
@@ -111,9 +111,9 @@ public:
     unsigned char cost = 0;
     if (distance == 0)
       cost = LETHAL_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_)
+    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE;
-    else if (distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
+    else if (!local_costmap_ && distance * resolution_ <= inscribed_radius_ + impassable_margin_ + path_avoidance_margin_)
       cost = INSCRIBED_INFLATED_OBSTACLE - 1;
     else
     {

--- a/costmap_2d/include/costmap_2d/variable_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/variable_inflation_layer.h
@@ -135,6 +135,7 @@ public:
    * @param max_inflation_vel The maximum velocity to activate variable inflation
    * @param impassable_margin The margin to apply to no entry cost values.
    * @param path_avoidance_margin The margin to apply to path distance when avoiding obstacles.
+   * @param local_costmap Whether to use it for local cost mapping
    */
   void setInflationParameters(double inflation_radius,
                               double cost_scaling_factor,
@@ -143,7 +144,8 @@ public:
                               double min_inflation_vel,
                               double max_inflation_vel,
                               double impassable_margin,
-                              double path_avoidance_margin);
+                              double path_avoidance_margin,
+                              bool local_costmap);
 
 protected:
   virtual void onFootprintChanged();
@@ -161,6 +163,7 @@ protected:
   double max_inflation_vel_ = 0.6;
   double path_avoidance_margin_;
   double impassable_margin_;
+  bool local_costmap_;
 
 private:
   /**

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -107,7 +107,7 @@ void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, ui
     config.cost_scaling_factor,
     config.path_avoidance_margin,
     config.impassable_margin,
-    config.local_costmap);
+    config.disable_inscribed_inflated_obstacle);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -374,11 +374,11 @@ void InflationLayer::deleteKernels()
 
 void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor,
                                             double path_avoidance_margin, double impassable_margin,
-                                            bool local_costmap)
+                                            bool disable_inscribed_inflated_obstacle)
 {
   if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
       path_avoidance_margin_ != path_avoidance_margin || impassable_margin_ != impassable_margin ||
-      local_costmap_ != local_costmap)
+      disable_inscribed_inflated_obstacle_ != disable_inscribed_inflated_obstacle)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -389,7 +389,7 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
     weight_ = cost_scaling_factor;
     path_avoidance_margin_ = path_avoidance_margin;
     impassable_margin_ = impassable_margin;
-    local_costmap_ = local_costmap;
+    disable_inscribed_inflated_obstacle_ = disable_inscribed_inflated_obstacle;
     need_reinflation_ = true;
     computeCaches();
   }

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -102,7 +102,12 @@ void InflationLayer::onInitialize()
 
 void InflationLayer::reconfigureCB(costmap_2d::InflationPluginConfig &config, uint32_t level)
 {
-  setInflationParameters(config.inflation_radius, config.cost_scaling_factor, config.path_avoidance_margin, config.impassable_margin);
+  setInflationParameters(
+    config.inflation_radius,
+    config.cost_scaling_factor,
+    config.path_avoidance_margin,
+    config.impassable_margin,
+    config.local_costmap);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -368,10 +373,12 @@ void InflationLayer::deleteKernels()
 }
 
 void InflationLayer::setInflationParameters(double inflation_radius, double cost_scaling_factor,
-                                            double path_avoidance_margin, double impassable_margin)
+                                            double path_avoidance_margin, double impassable_margin,
+                                            bool local_costmap)
 {
   if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
-      path_avoidance_margin_ != path_avoidance_margin || impassable_margin_ != impassable_margin)
+      path_avoidance_margin_ != path_avoidance_margin || impassable_margin_ != impassable_margin ||
+      local_costmap_ != local_costmap)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -382,6 +389,7 @@ void InflationLayer::setInflationParameters(double inflation_radius, double cost
     weight_ = cost_scaling_factor;
     path_avoidance_margin_ = path_avoidance_margin;
     impassable_margin_ = impassable_margin;
+    local_costmap_ = local_costmap;
     need_reinflation_ = true;
     computeCaches();
   }

--- a/costmap_2d/plugins/variable_inflation_layer.cpp
+++ b/costmap_2d/plugins/variable_inflation_layer.cpp
@@ -115,7 +115,8 @@ void VariableInflationLayer::reconfigureCB(costmap_2d::VariableInflationPluginCo
   setInflationParameters(config.inflation_radius, config.cost_scaling_factor,
                          config.min_inflation_radius, config.max_inflation_radius,
                          config.min_inflation_vel, config.max_inflation_vel,
-                         config.impassable_margin, config.path_avoidance_margin);
+                         config.impassable_margin, config.path_avoidance_margin,
+                         config.local_costmap);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -224,7 +225,8 @@ void VariableInflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int
   setInflationParameters(variable_inflation_radius, weight_,
                          min_inflation_radius_, max_inflation_radius_,
                          min_inflation_vel_, max_inflation_vel_,
-                         impassable_margin_, path_avoidance_margin_);
+                         impassable_margin_, path_avoidance_margin_,
+                         local_costmap_);
 
   if (!enabled_ || (cell_inflation_radius_ == 0))
     return;
@@ -424,12 +426,14 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
                                                     double min_inflation_vel,
                                                     double max_inflation_vel,
                                                     double impassable_margin,
-                                                    double path_avoidance_margin)
+                                                    double path_avoidance_margin,
+                                                    bool local_costmap)
 {
   if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
       min_inflation_radius_ != min_inflation_radius || max_inflation_radius_ != max_inflation_radius ||
       min_inflation_vel_ != min_inflation_vel || max_inflation_vel_ != max_inflation_vel ||
-      impassable_margin_ != impassable_margin || path_avoidance_margin_ != path_avoidance_margin)
+      impassable_margin_ != impassable_margin || path_avoidance_margin_ != path_avoidance_margin ||
+      local_costmap_ != local_costmap)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -445,6 +449,7 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
     max_inflation_vel_ = max_inflation_vel;
     path_avoidance_margin_ = path_avoidance_margin;
     impassable_margin_ = impassable_margin;
+    local_costmap_ = local_costmap;
     need_reinflation_ = true;
     computeCaches();
   }

--- a/costmap_2d/plugins/variable_inflation_layer.cpp
+++ b/costmap_2d/plugins/variable_inflation_layer.cpp
@@ -116,7 +116,7 @@ void VariableInflationLayer::reconfigureCB(costmap_2d::VariableInflationPluginCo
                          config.min_inflation_radius, config.max_inflation_radius,
                          config.min_inflation_vel, config.max_inflation_vel,
                          config.impassable_margin, config.path_avoidance_margin,
-                         config.local_costmap);
+                         config.disable_inscribed_inflated_obstacle);
 
   if (enabled_ != config.enabled || inflate_unknown_ != config.inflate_unknown) {
     enabled_ = config.enabled;
@@ -226,7 +226,7 @@ void VariableInflationLayer::updateCosts(costmap_2d::Costmap2D& master_grid, int
                          min_inflation_radius_, max_inflation_radius_,
                          min_inflation_vel_, max_inflation_vel_,
                          impassable_margin_, path_avoidance_margin_,
-                         local_costmap_);
+                         disable_inscribed_inflated_obstacle_);
 
   if (!enabled_ || (cell_inflation_radius_ == 0))
     return;
@@ -427,13 +427,13 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
                                                     double max_inflation_vel,
                                                     double impassable_margin,
                                                     double path_avoidance_margin,
-                                                    bool local_costmap)
+                                                    bool disable_inscribed_inflated_obstacle)
 {
   if (weight_ != cost_scaling_factor || inflation_radius_ != inflation_radius ||
       min_inflation_radius_ != min_inflation_radius || max_inflation_radius_ != max_inflation_radius ||
       min_inflation_vel_ != min_inflation_vel || max_inflation_vel_ != max_inflation_vel ||
       impassable_margin_ != impassable_margin || path_avoidance_margin_ != path_avoidance_margin ||
-      local_costmap_ != local_costmap)
+      disable_inscribed_inflated_obstacle_ != disable_inscribed_inflated_obstacle)
   {
     // Lock here so that reconfiguring the inflation radius doesn't cause segfaults
     // when accessing the cached arrays
@@ -449,7 +449,7 @@ void VariableInflationLayer::setInflationParameters(double inflation_radius,
     max_inflation_vel_ = max_inflation_vel;
     path_avoidance_margin_ = path_avoidance_margin;
     impassable_margin_ = impassable_margin;
-    local_costmap_ = local_costmap;
+    disable_inscribed_inflated_obstacle_ = disable_inscribed_inflated_obstacle;
     need_reinflation_ = true;
     computeCaches();
   }


### PR DESCRIPTION
## Close Ticket
AMRSW-1577

## Description
Added the ability to turn off the Footprint minimum radius distance impenetrable area when adding an inflation layer to the local cost map.
This will prevent the user from unnecessarily getting stuck on an obstruction.

As a temporary solution, this was achieved by specifying a negative value for impassable_margin, but a separate flag by local cost map has been specified.

## Testing

v63002
parameter to ensure that no impenetrable areas are created for inflation.
