### PR TITLE
[AMRSW-1580] goal skipping issue

### DIFF
--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -297,6 +297,7 @@ namespace move_base {
       move_base::MoveBaseConfig default_config_;
       bool setup_, p_freq_change_, c_freq_change_;
       bool new_global_plan_;
+      bool check_plan_validity_;
   };
 };
 #endif

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -105,11 +105,10 @@ namespace move_base {
     private_nh.param("detect_motion_abs_wz", detect_motion_abs_wz_, 5 * M_PI / 180);
 
     private_nh.param("new_global_plan_delay_sec", new_global_plan_delay_sec_, 0.0);
+    private_nh.param("check_plan_validity", check_plan_validity_, true);
     // parameters of make_plan service
     private_nh.param("make_plan_clear_costmap", make_plan_clear_costmap_, true);
     private_nh.param("make_plan_add_unreachable_goal", make_plan_add_unreachable_goal_, true);
-
-    private_nh.param("check_plan_validity", check_plan_validity_, true);
 
     //set up plan triple buffer
     planner_plan_ = new std::vector<geometry_msgs::PoseStamped>();
@@ -707,7 +706,7 @@ namespace move_base {
         if  (fabs(temp_goal.pose.position.x - planner_goal_.pose.position.x) > std::numeric_limits<float>::epsilon() ||
             fabs(temp_goal.pose.position.y - planner_goal_.pose.position.y) > std::numeric_limits<float>::epsilon())
         {
-          ROS_INFO("The goal changed while we where planning skipping plan");
+          ROS_INFO("The goal changed while we were planning: skipping plan");
           gotPlan = false;
         }
         lock.unlock();

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -109,6 +109,8 @@ namespace move_base {
     private_nh.param("make_plan_clear_costmap", make_plan_clear_costmap_, true);
     private_nh.param("make_plan_add_unreachable_goal", make_plan_add_unreachable_goal_, true);
 
+    private_nh.param("check_plan_validity", check_plan_validity_, true);
+
     //set up plan triple buffer
     planner_plan_ = new std::vector<geometry_msgs::PoseStamped>();
     latest_plan_ = new std::vector<geometry_msgs::PoseStamped>();
@@ -699,16 +701,14 @@ namespace move_base {
       //run planner
       planner_plan_->clear();
       bool gotPlan = n.ok() && makePlan(temp_goal, *planner_plan_);
-      if(gotPlan){
+      if(check_plan_validity_ && gotPlan){
         lock.lock();
-        //check if the plan we made is still valid
-        //make plan can take some time
-        if(fabs(temp_goal.pose.position.x - planner_goal_.pose.position.x) > std::numeric_limits<float>::epsilon() ||
+        //  make plan can take some time so check if the plan we made is still for the current goal
+        if  (fabs(temp_goal.pose.position.x - planner_goal_.pose.position.x) > std::numeric_limits<float>::epsilon() ||
             fabs(temp_goal.pose.position.y - planner_goal_.pose.position.y) > std::numeric_limits<float>::epsilon())
         {
-          ROS_INFO("Cancel goal planning");
+          ROS_INFO("The goal changed while we where planning skipping plan");
           gotPlan = false;
-
         }
         lock.unlock();
       }

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -707,7 +707,7 @@ namespace move_base {
         if  (fabs(temp_goal.pose.position.x - planner_goal_.pose.position.x) > std::numeric_limits<float>::epsilon() ||
             fabs(temp_goal.pose.position.y - planner_goal_.pose.position.y) > std::numeric_limits<float>::epsilon())
         {
-          ROS_INFO("The goal changed while we where planning skipping plan");
+          ROS_INFO("The goal changed while we were planning: skipping plan");
           gotPlan = false;
         }
         lock.unlock();

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -699,7 +699,19 @@ namespace move_base {
       //run planner
       planner_plan_->clear();
       bool gotPlan = n.ok() && makePlan(temp_goal, *planner_plan_);
+      if(gotPlan){
+        lock.lock();
+        //check if the plan we made is still valid
+        //make plan can take some time
+        if(fabs(temp_goal.pose.position.x - planner_goal_.pose.position.x) > std::numeric_limits<float>::epsilon() ||
+            fabs(temp_goal.pose.position.y - planner_goal_.pose.position.y) > std::numeric_limits<float>::epsilon())
+        {
+          ROS_INFO("Cancel goal planning");
+          gotPlan = false;
 
+        }
+        lock.unlock();
+      }
       if(gotPlan){
         ROS_DEBUG_NAMED("move_base_plan_thread","Got Plan with %zu points!", planner_plan_->size());
 


### PR DESCRIPTION
## Close Ticket

AMRSW-1580

## Description

If the goal is not Cancelled and a new goal is send.
It can happen that a new goal is send to move base while the execution is not done, if the goal is accepted and the planning thread was already running `makePlan` with the old goal, it might happens that when make plan finishes the plan made is for the previous goal, after that the state will be set to CONTROLLING and soon to SUCCEEDED because we are already close to the previous goal.
To avoid this I added a check after makePlan to check if the plan made is still for the current goal or is the goal was changed while the plan was made.

