### PR TITLE
fix segmentation fault.

### DIFF
--- a/costmap_2d/include/costmap_2d/inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/inflation_layer.h
@@ -158,6 +158,17 @@ private:
   {
     unsigned int dx = abs(mx - src_x);
     unsigned int dy = abs(my - src_y);
+
+    if (cached_distances_ == NULL || dx > cell_inflation_radius_ + 1 || dy > cell_inflation_radius_ + 1)
+    {
+      // This array bounds violation should not normally occur since the mutex issue
+      // has been fixed. This log output serves as a failsafe fallback.
+      ROS_ERROR_THROTTLE(5.0, "InflationLayer::distanceLookup(): Array bounds exceeded. "
+                         "dx=%u, dy=%u, max_allowed=%u, src_x=%d, src_y=%d, mx=%d, my=%d",
+                         dx, dy, cell_inflation_radius_ + 1, src_x, src_y, mx, my);
+      return cell_inflation_radius_ + 1;
+    }
+
     return cached_distances_[dx][dy];
   }
 
@@ -173,6 +184,17 @@ private:
   {
     unsigned int dx = abs(mx - src_x);
     unsigned int dy = abs(my - src_y);
+
+    if (cached_costs_ == NULL || dx > cell_inflation_radius_ + 1 || dy > cell_inflation_radius_ + 1)
+    {
+      // This array bounds violation should not normally occur since the mutex issue
+      // has been fixed. This log output serves as a failsafe fallback.
+      ROS_ERROR_THROTTLE(5.0, "InflationLayer::costLookup(): Array bounds exceeded. "
+                         "dx=%u, dy=%u, max_allowed=%u, src_x=%d, src_y=%d, mx=%d, my=%d",
+                         dx, dy, cell_inflation_radius_ + 1, src_x, src_y, mx, my);
+      return 0;
+    }
+
     return cached_costs_[dx][dy];
   }
 

--- a/costmap_2d/include/costmap_2d/variable_inflation_layer.h
+++ b/costmap_2d/include/costmap_2d/variable_inflation_layer.h
@@ -178,6 +178,17 @@ private:
   {
     unsigned int dx = abs(mx - src_x);
     unsigned int dy = abs(my - src_y);
+
+    if (cached_distances_ == NULL || dx > cell_inflation_radius_ + 1 || dy > cell_inflation_radius_ + 1)
+    {
+      // This array bounds violation should not normally occur since the mutex issue
+      // has been fixed. This log output serves as a failsafe fallback.
+      ROS_ERROR_THROTTLE(5.0, "VariableInflationLayer::distanceLookup(): Array bounds exceeded. "
+                         "dx=%u, dy=%u, max_allowed=%u, src_x=%d, src_y=%d, mx=%d, my=%d",
+                         dx, dy, cell_inflation_radius_ + 1, src_x, src_y, mx, my);
+      return cell_inflation_radius_ + 1;
+    }
+
     return cached_distances_[dx][dy];
   }
 
@@ -193,6 +204,17 @@ private:
   {
     unsigned int dx = abs(mx - src_x);
     unsigned int dy = abs(my - src_y);
+
+    if (cached_costs_ == NULL || dx > cell_inflation_radius_ + 1 || dy > cell_inflation_radius_ + 1)
+    {
+      // This array bounds violation should not normally occur since the mutex issue
+      // has been fixed. This log output serves as a failsafe fallback.
+      ROS_ERROR_THROTTLE(5.0, "VariableInflationLayer::costLookup(): Array bounds exceeded. "
+                         "dx=%u, dy=%u, max_allowed=%u, src_x=%d, src_y=%d, mx=%d, my=%d",
+                         dx, dy, cell_inflation_radius_ + 1, src_x, src_y, mx, my);
+      return 0;
+    }
+
     return cached_costs_[dx][dy];
   }
 

--- a/costmap_2d/plugins/inflation_layer.cpp
+++ b/costmap_2d/plugins/inflation_layer.cpp
@@ -168,6 +168,7 @@ void InflationLayer::updateBounds(double robot_x, double robot_y, double robot_y
 
 void InflationLayer::onFootprintChanged()
 {
+  boost::unique_lock<boost::recursive_mutex> lock(*inflation_access_);
   inscribed_radius_ = layered_costmap_->getInscribedRadius();
   cell_inflation_radius_ = cellDistance(inflation_radius_);
   computeCaches();


### PR DESCRIPTION
## Close Ticket

Fix inflation layer race condition causing segmentation fault
AMRSW-1484

## Description

Fixed a race condition in InflationLayer and VariableInflationLayer that was causing segmentation faults during frequent footprint changes from lexxtug encoders. The issue occurred when onFootprintChanged() (Thread A) was calling computeCaches() to delete/recreate cached arrays while
mapUpdateLoop() (Thread B) was accessing those same arrays in costLookup().

**Changes made:**
- Added mutex lock in InflationLayer::onFootprintChanged() to prevent race condition
- Added boundary checks in both distanceLookup() and costLookup() methods for failsafe fallback
- Added ROS_ERROR_THROTTLE logging for array bounds violations as safety net
- Applied same fixes to both InflationLayer and VariableInflationLayer for consistency

## Testing

Tested with normal navigation including footprint changes during operation.

- [x] Test normal navigation with footprint changes
  - [x] No segmentation faults occur
  - [x] Normal inflation behavior maintained
  - [x] Navigation continues normally with footprint changes from lexxtug encoders

## Visualization

None

## Dependent PRs (if any)

None