### PR TITLE
feat/AMRSW-2129 PolygonCostmap support and reinitialize_costmaps service

### DIFF
--- a/costmap_2d/include/costmap_2d/costmap_2d_ros.h
+++ b/costmap_2d/include/costmap_2d/costmap_2d_ros.h
@@ -115,6 +115,14 @@ public:
    */
   void resetLayers();
 
+  /**
+   * @brief Reinitialize all layers via a full stop/start cycle.
+   * Deactivates all layers, unlocks size constraints, then re-activates,
+   * causing each layer to re-run its initialization and re-subscribe
+   * to data sources.
+   */
+  void reinitializeLayers();
+
   /** @brief Same as getLayeredCostmap()->isCurrent(). */
   bool isCurrent()
     {

--- a/costmap_2d/include/costmap_2d/layered_costmap.h
+++ b/costmap_2d/include/costmap_2d/layered_costmap.h
@@ -119,6 +119,11 @@ public:
     return size_locked_;
   }
 
+  void unlockSize()
+  {
+    size_locked_ = false;
+  }
+
   void getBounds(unsigned int* x0, unsigned int* xn, unsigned int* y0, unsigned int* yn)
   {
     *x0 = bx0_;

--- a/costmap_2d/plugins/static_layer.cpp
+++ b/costmap_2d/plugins/static_layer.cpp
@@ -251,8 +251,12 @@ void StaticLayer::activate()
 void StaticLayer::deactivate()
 {
   map_sub_.shutdown();
+  map_sub_ = ros::Subscriber();
   if (subscribe_to_updates_)
+  {
     map_update_sub_.shutdown();
+    map_update_sub_ = ros::Subscriber();
+  }
 }
 
 void StaticLayer::reset()

--- a/costmap_2d/src/costmap_2d_ros.cpp
+++ b/costmap_2d/src/costmap_2d_ros.cpp
@@ -609,6 +609,14 @@ void Costmap2DROS::resetLayers()
   }
 }
 
+void Costmap2DROS::reinitializeLayers()
+{
+  ROS_INFO("Reinitializing costmap layers");
+  stop();
+  layered_costmap_->unlockSize();
+  start();
+}
+
 bool Costmap2DROS::getRobotPose(geometry_msgs::PoseStamped& global_pose) const
 {
   tf2::toMsg(tf2::Transform::getIdentity(), global_pose.pose);

--- a/move_base/include/move_base/move_base.h
+++ b/move_base/include/move_base/move_base.h
@@ -125,6 +125,13 @@ namespace move_base {
       bool clearCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
 
       /**
+       * @brief  Reinitialize all costmap layers.
+       * Performs a full stop/start cycle, re-running layer initialization
+       * to ensure costmap state is consistent after plugin reconfiguration.
+       */
+      bool reinitializeCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp);
+
+      /**
        * @brief  Clears the costmaps of obstacles
        * @return True if the service call succeeds, false otherwise
        */
@@ -244,7 +251,7 @@ namespace move_base {
       ros::Publisher current_goal_pub_, vel_pub_, action_goal_pub_, recovery_status_pub_;
       ros::Publisher amr_status_pub_, virtual_obstacle_enabled_pub_, dist_to_current_goal_pub_;
       ros::Subscriber goal_sub_, carrying_info_sub_, action_goal_sub_;
-      ros::ServiceServer make_plan_srv_, clear_costmaps_srv_;
+      ros::ServiceServer make_plan_srv_, clear_costmaps_srv_, reinitialize_costmaps_srv_;
       bool shutdown_costmaps_, clearing_rotation_allowed_, recovery_behavior_enabled_, backward_recovery_allowed_, abort_after_recovery_allowed_;
       bool remove_virtual_obstacle_recovery_allowed_;
       bool conservative_clearing_map_allowed_, aggressive_clearing_map_allowed_;

--- a/move_base/src/move_base.cpp
+++ b/move_base/src/move_base.cpp
@@ -190,6 +190,9 @@ namespace move_base {
     //advertise a service for clearing the costmaps
     clear_costmaps_srv_ = private_nh.advertiseService("clear_costmaps", &MoveBase::clearCostmapsService, this);
 
+    //advertise a service for reinitializing costmaps (full layer re-initialization)
+    reinitialize_costmaps_srv_ = private_nh.advertiseService("reinitialize_costmaps", &MoveBase::reinitializeCostmapsService, this);
+
     //if we shutdown our costmaps when we're deactivated... we'll do that now
     if(shutdown_costmaps_){
       ROS_DEBUG_NAMED("move_base","Stopping costmaps initially");
@@ -420,6 +423,13 @@ namespace move_base {
     planner_costmap_ros_->resetLayers();
     planner_costmap_ros_->updateMap();
 
+    return true;
+  }
+
+  bool MoveBase::reinitializeCostmapsService(std_srvs::Empty::Request &req, std_srvs::Empty::Response &resp){
+    ROS_INFO("Reinitializing costmaps");
+    planner_costmap_ros_->reinitializeLayers();
+    controller_costmap_ros_->reinitializeLayers();
     return true;
   }
 

--- a/remove_virtual_obstacle_recovery/CMakeLists.txt
+++ b/remove_virtual_obstacle_recovery/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   base_local_planner
   costmap_2d
   geometry_msgs
+  topic_tools
   nav_core
   pluginlib
   roscpp
@@ -20,6 +21,7 @@ catkin_package(
     base_local_planner
     costmap_2d
     geometry_msgs
+    topic_tools
     nav_core
     pluginlib
     roscpp

--- a/remove_virtual_obstacle_recovery/include/remove_virtual_obstacle_recovery/remove_virtual_obstacle_recovery.h
+++ b/remove_virtual_obstacle_recovery/include/remove_virtual_obstacle_recovery/remove_virtual_obstacle_recovery.h
@@ -4,6 +4,7 @@
 #include <costmap_2d/costmap_2d_ros.h>
 #include <ros/ros.h>
 #include <std_msgs/Bool.h>
+#include <topic_tools/shape_shifter.h>
 
 namespace remove_virtual_obstacle_recovery
 {
@@ -24,7 +25,7 @@ class RemoveVirtualObstacleRecovery : public nav_core::RecoveryBehavior
         ros::Publisher virtual_obstacle_enabled_pub_;
         ros::Subscriber virtual_obstacle_map_sub_;
 
-        void virtualObstacleMapCallback(const nav_msgs::OccupancyGrid::ConstPtr& msg);
+        void virtualObstacleMapCallback(const topic_tools::ShapeShifter::ConstPtr& msg);
 };
 };  // namespace remove_virtual_obstacle_recovery
 

--- a/remove_virtual_obstacle_recovery/package.xml
+++ b/remove_virtual_obstacle_recovery/package.xml
@@ -16,6 +16,7 @@
   <depend>costmap_2d</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_core</depend>
+  <depend>topic_tools</depend>
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>tf2</depend>

--- a/remove_virtual_obstacle_recovery/src/remove_virtual_obstacle_recovery.cpp
+++ b/remove_virtual_obstacle_recovery/src/remove_virtual_obstacle_recovery.cpp
@@ -32,7 +32,7 @@ RemoveVirtualObstacleRecovery::~RemoveVirtualObstacleRecovery()
 {
 }
 
-void RemoveVirtualObstacleRecovery::virtualObstacleMapCallback(const nav_msgs::OccupancyGrid::ConstPtr& msg)
+void RemoveVirtualObstacleRecovery::virtualObstacleMapCallback(const topic_tools::ShapeShifter::ConstPtr& msg)
 {
     this->virtual_obstacle_map_received_ = true;
 }


### PR DESCRIPTION
## Close Ticket

AMRSW-2129

## Description

Add costmap layer re-initialization support and PolygonCostmap-related changes for virtual obstacle load reduction.

Key changes:
- `reinitialize_costmaps` service in move_base: full stop/unlockSize/start cycle for costmap layer re-initialization
- `LayeredCostmap::unlockSize()`: release size constraint for re-initialization
- `StaticLayer::deactivate()`: clear subscriber so re-activation properly re-subscribes to latched topics
- `RemoveVirtualObstacleRecovery`: use ShapeShifter for message-type-agnostic subscription (supports both OccupancyGrid and PolygonCostmap)

## Testing

AMR used: v63033

- [x] reinitialize_costmaps resizes costmap correctly (small to large map)
- [x] reinitialize_costmaps resizes costmap correctly (large to small map)
- [x] Map data is correctly loaded after reinitialize
- [x] StaticLayer properly re-subscribes to latched /map after deactivate/activate cycle
- [x] RemoveVirtualObstacleRecovery receives messages regardless of message type
- [x] Existing clear_costmaps behavior is unaffected

## Visualization

N/A

## Dependent PRs (if any)

- LexxPluss/LexxAuto#4190